### PR TITLE
feat: アルバム・画像投稿機能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ coverage/*
 config/database.yml
 
 .solargraph.yml
+
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ group :development, :test do
   # test
   gem 'factory_bot_rails'
   gem 'rspec-rails'
+  #デバック
+  gem 'pry-byebug'
 end
 
 group :test do
@@ -59,7 +61,6 @@ group :development do
   # デバックツール
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'pry-byebug'
   # コード補完
   gem 'solargraph'
   # モデルファイルにカラムを表示

--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,5 @@ gem 'devise'
 gem 'rails-i18n'
 # devise日本語化
 gem 'devise-i18n'
+#画像投稿
+gem 'carrierwave'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development, :test do
   # test
   gem 'factory_bot_rails'
   gem 'rspec-rails'
-  #デバック
+  # デバック
   gem 'pry-byebug'
 end
 
@@ -79,5 +79,5 @@ gem 'devise'
 gem 'rails-i18n'
 # devise日本語化
 gem 'devise-i18n'
-#画像投稿
+# 画像投稿
 gem 'carrierwave'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (2.2.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -120,6 +128,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -139,6 +150,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.16.0)
     msgpack (1.5.2)
@@ -257,6 +269,8 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -303,6 +317,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.0.7)
     strscan (3.0.3)
     thor (1.2.1)
     tilt (2.0.10)
@@ -350,6 +365,7 @@ DEPENDENCIES
   bullet
   byebug
   capybara
+  carrierwave
   devise
   devise-i18n
   factory_bot_rails

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -2,7 +2,7 @@ class GraduationAlbumsController < ApplicationController
   before_action :set_graduation_album, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, only: %i[new create edit update destroy]
   def index
-    @graduation_albums = GraduationAlbum.all.order(created_at: :desc)
+    @graduation_albums = GraduationAlbum.all.includes(:user).order(created_at: :desc)
   end
 
   def show; end

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -1,0 +1,14 @@
+class GraduationAlbumsController < ApplicationController
+  def index
+  end
+
+  def show
+  end
+
+  def new
+    @graduation_album = GraduationAlbum.new
+  end
+
+  def edit
+  end
+end

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 class GraduationAlbumsController < ApplicationController
-  before_action :set_graduation_album, only: [:show, :edit, :update, :destroy]
+  before_action :set_graduation_album, only: %i[show edit update destroy]
   before_action :authenticate_user!, only: %i[new create edit update destroy]
   def index
     @graduation_albums = GraduationAlbum.all.includes(:user).order(created_at: :desc)
@@ -39,8 +41,8 @@ class GraduationAlbumsController < ApplicationController
 
   private
 
-  def graduation_album_params 
-    params.require(:graduation_album).permit(:album_name, :title, {photos: []})
+  def graduation_album_params
+    params.require(:graduation_album).permit(:album_name, :title, { photos: [] })
   end
 
   def set_graduation_album

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -35,6 +35,12 @@ class GraduationAlbumsController < ApplicationController
     end
   end
 
+  def destroy
+  graduation_album = GraduationAlbum.find(params[:id])
+  graduation_album.destroy!
+  redirect_to graduation_albums_path
+end
+
   private
 
   def graduation_album_params 

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -1,11 +1,11 @@
 class GraduationAlbumsController < ApplicationController
+  before_action :set_graduation_album, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_user!, only: %i[new create edit update destroy]
   def index
     @graduation_albums = GraduationAlbum.all.order(created_at: :desc)
   end
 
-  def show
-    @graduation_album = GraduationAlbum.find(params[:id])
-  end
+  def show; end
 
   def new
     @graduation_album = GraduationAlbum.new
@@ -21,13 +21,10 @@ class GraduationAlbumsController < ApplicationController
     end
   end
 
-  def edit
-    @graduation_album = GraduationAlbum.find(params[:id])
-  end
+  def edit; end
 
   def update
-    graduation_album = GraduationAlbum.find(params[:id])
-    if graduation_album.update(graduation_album_params)
+    if @graduation_album.update(graduation_album_params)
       redirect_to graduation_albums_path, notice: '編集に成功しました'
     else
       flash.now['alert'] = '編集に失敗しました'
@@ -36,8 +33,7 @@ class GraduationAlbumsController < ApplicationController
   end
 
   def destroy
-    graduation_album = GraduationAlbum.find(params[:id])
-    graduation_album.destroy!
+    @graduation_album.destroy!
     redirect_to graduation_albums_path, notice: 'アルバムの削除に成功しました'
   end
 
@@ -45,5 +41,9 @@ class GraduationAlbumsController < ApplicationController
 
   def graduation_album_params 
     params.require(:graduation_album).permit(:album_name, :title)
+  end
+
+  def set_graduation_album
+    @graduation_album = current_user.graduation_albums.find(params[:id])
   end
 end

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -28,18 +28,18 @@ class GraduationAlbumsController < ApplicationController
   def update
     graduation_album = GraduationAlbum.find(params[:id])
     if graduation_album.update(graduation_album_params)
-      redirect_to graduation_albums_path, notice: '作成に成功しました'
+      redirect_to graduation_albums_path, notice: '編集に成功しました'
     else
-      flash.now['alert'] = '作成に失敗しました'
+      flash.now['alert'] = '編集に失敗しました'
       render :edit
     end
   end
 
   def destroy
-  graduation_album = GraduationAlbum.find(params[:id])
-  graduation_album.destroy!
-  redirect_to graduation_albums_path
-end
+    graduation_album = GraduationAlbum.find(params[:id])
+    graduation_album.destroy!
+    redirect_to graduation_albums_path, notice: 'アルバムの削除に成功しました'
+  end
 
   private
 

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -4,6 +4,7 @@ class GraduationAlbumsController < ApplicationController
   end
 
   def show
+    @graduation_album = GraduationAlbum.find(params[:id])
   end
 
   def new

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -21,9 +21,18 @@ class GraduationAlbumsController < ApplicationController
     end
   end
 
-
-
   def edit
+    @graduation_album = GraduationAlbum.find(params[:id])
+  end
+
+  def update
+    graduation_album = GraduationAlbum.find(params[:id])
+    if graduation_album.update(graduation_album_params)
+      redirect_to graduation_albums_path, notice: '作成に成功しました'
+    else
+      flash.now['alert'] = '作成に失敗しました'
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -40,7 +40,7 @@ class GraduationAlbumsController < ApplicationController
   private
 
   def graduation_album_params 
-    params.require(:graduation_album).permit(:album_name, :title)
+    params.require(:graduation_album).permit(:album_name, :title, {photos: []})
   end
 
   def set_graduation_album

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -1,5 +1,6 @@
 class GraduationAlbumsController < ApplicationController
   def index
+    @graduation_albums = GraduationAlbum.all.order(created_at: :desc)
   end
 
   def show
@@ -9,6 +10,24 @@ class GraduationAlbumsController < ApplicationController
     @graduation_album = GraduationAlbum.new
   end
 
+  def create
+    @graduation_album = current_user.graduation_albums.build(graduation_album_params)
+    if @graduation_album.save
+      redirect_to graduation_albums_path, notice: '作成に成功しました'
+    else
+      flash.now['alert'] = '作成に失敗しました'
+      render :new
+    end
+  end
+
+
+
   def edit
+  end
+
+  private
+
+  def graduation_album_params 
+    params.require(:graduation_album).permit(:album_name, :title)
   end
 end

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  album_name :string           not null
+#  photos     :json
 #  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -18,6 +19,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class GraduationAlbum < ApplicationRecord
+  mount_uploaders :photos, PhotoUploader
   belongs_to :user
 
   validates :title, :album_name, presence: true, length: { maximum: 255 }

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: graduation_albums

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: graduation_albums
+#
+#  id         :bigint           not null, primary key
+#  album_name :string           not null
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_graduation_albums_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class GraduationAlbum < ApplicationRecord
+  belongs_to :user
+
+  validates :title, :album_name, presence: true
+end

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -20,5 +20,5 @@
 class GraduationAlbum < ApplicationRecord
   belongs_to :user
 
-  validates :title, :album_name, presence: true
+  validates :title, :album_name, presence: true, length: { maximum: 255 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,7 +25,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_many :graduation_albums
-  
+
   validates :email, uniqueness: true
   validates :email, presence: true
   validates :name, presence: true, length: { maximum: 255 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,8 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :graduation_albums
+  
   validates :email, uniqueness: true
   validates :email, presence: true
   validates :name, presence: true, length: { maximum: 255 }

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -1,0 +1,47 @@
+class PhotoUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_allowlist
+    %w(jpg jpeg gif png)
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PhotoUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
@@ -36,7 +38,7 @@ class PhotoUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w(jpg jpeg gif png)
+    %w[jpg jpeg gif png]
   end
 
   # Override the filename of the uploaded files:

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -1,0 +1,15 @@
+<div class="mt-8">
+  <%= form_with model: graduation_album, class:"w-10/12 mx-auto md:max-w-md", local: true do |f| %>
+    <div class="mb-8">
+      <%= f.label :title, class: "text-sm block"%>
+      <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+    </div>
+    <div class="mb-8">
+      <%= f.label :album_name, class: "text-sm block"%>
+      <%= f.text_field :album_name, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+    </div>
+    <div class='form-control mt-6'>
+      <%= f.submit '作成する', class: 'btn btn-primary' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -1,5 +1,6 @@
 <div class="mt-8">
   <%= form_with model: graduation_album, class:"w-10/12 mx-auto md:max-w-md", local: true do |f| %>
+  <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :title, class: "text-sm block"%>
       <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -11,7 +11,11 @@
     </div>
     <div class="mb-8">
       <%= f.label :photos, class: "text-sm block"%>
-      <%= f.file_field :photos, multiple: true, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <% graduation_album.photos.each do |photo| %>
+        <%= hidden_field :graduation_album, :photos, multiple: true, value: photo.identifier %>
+        <%= image_tag photo.url, size: '300x200' %>
+      <% end %>
+      <%= f.file_field :photos, multiple: true, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50' %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -9,6 +9,10 @@
       <%= f.label :album_name, class: "text-sm block"%>
       <%= f.text_field :album_name, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
     </div>
+    <div class="mb-8">
+      <%= f.label :photos, class: "text-sm block"%>
+      <%= f.file_field :photos, multiple: true, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+    </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>
     </div>

--- a/app/views/graduation_albums/_graduation_album.html.erb
+++ b/app/views/graduation_albums/_graduation_album.html.erb
@@ -4,5 +4,6 @@
   </a>
   <div class="flex flex-col">
     <%= link_to graduation_album.album_name, graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+    <%= link_to '編集', edit_graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
   </div>
 </div>

--- a/app/views/graduation_albums/_graduation_album.html.erb
+++ b/app/views/graduation_albums/_graduation_album.html.erb
@@ -1,0 +1,8 @@
+<div>
+  <a href="#" class="group h-96 block bg-gray-100 rounded-lg overflow-hidden shadow-lg mb-2 lg:mb-3">
+    <img src="https://images.unsplash.com/photo-1552374196-1ab2a1c593e8?auto=format&q=75&fit=crop&crop=top&w=600&h=700" loading="lazy" alt="Photo by Austin Wade" class="w-full h-full object-cover object-center group-hover:scale-110 transition duration-200" />
+  </a>
+  <div class="flex flex-col">
+    <%= link_to graduation_album.album_name, '#', class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+  </div>
+</div>

--- a/app/views/graduation_albums/_graduation_album.html.erb
+++ b/app/views/graduation_albums/_graduation_album.html.erb
@@ -4,7 +4,9 @@
   </a>
   <div class="flex flex-col">
     <%= link_to graduation_album.album_name, graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-    <%= link_to '編集', edit_graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
-    <%= link_to '削除', graduation_album_path(graduation_album), method: :delete, data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+    <% if current_user == graduation_album.user %>
+      <%= link_to '編集', edit_graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
+      <%= link_to '削除', graduation_album_path(graduation_album), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+    <% end %>
   </div>
 </div>

--- a/app/views/graduation_albums/_graduation_album.html.erb
+++ b/app/views/graduation_albums/_graduation_album.html.erb
@@ -4,6 +4,7 @@
   </a>
   <div class="flex flex-col">
     <%= link_to graduation_album.album_name, graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-    <%= link_to '編集', edit_graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+    <%= link_to '編集', edit_graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
+    <%= link_to '削除', graduation_album_path(graduation_album), method: :delete, data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
   </div>
 </div>

--- a/app/views/graduation_albums/_graduation_album.html.erb
+++ b/app/views/graduation_albums/_graduation_album.html.erb
@@ -3,6 +3,6 @@
     <img src="https://images.unsplash.com/photo-1552374196-1ab2a1c593e8?auto=format&q=75&fit=crop&crop=top&w=600&h=700" loading="lazy" alt="Photo by Austin Wade" class="w-full h-full object-cover object-center group-hover:scale-110 transition duration-200" />
   </a>
   <div class="flex flex-col">
-    <%= link_to graduation_album.album_name, '#', class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+    <%= link_to graduation_album.album_name, graduation_album_path(graduation_album), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
   </div>
 </div>

--- a/app/views/graduation_albums/edit.html.erb
+++ b/app/views/graduation_albums/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', { graduation_album: @graduation_album } %>

--- a/app/views/graduation_albums/index.html.erb
+++ b/app/views/graduation_albums/index.html.erb
@@ -1,0 +1,18 @@
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+    <div class="flex justify-between items-end gap-4 mb-6">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold">Collections</h2>
+
+      <a href="#" class="inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 border text-gray-500 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-4 md:px-8 py-2 md:py-3">Show more</a>
+    </div>
+
+    <div class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 md:gap-x-6 gap-y-6">
+      <!-- アルバム -->
+      <% if @graduation_albums.present? %>
+        <%= render @graduation_albums %>
+      <% else %>
+        <p>投稿はありません</p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/graduation_albums/new.html.erb
+++ b/app/views/graduation_albums/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form', { graduation_album: @graduation_album } %>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -1,0 +1,59 @@
+<div class="bg-white pb-6 sm:pb-8 lg:pb-12">
+  <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+    <header class="flex justify-between items-center py-4 md:py-8 mb-4">
+      <!-- logo - start -->
+      <a href="/" class="inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo">
+        <svg width="95" height="94" viewBox="0 0 95 94" class="w-6 h-auto text-indigo-500" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+          <path d="M96 0V47L48 94H0V47L48 0H96Z" />
+        </svg>
+
+        <%= @graduation_album.title %>
+      </a>
+      <!-- logo - end -->
+
+      <!-- nav - start -->
+      <nav class="hidden lg:flex gap-12">
+        <a href="#" class="text-indigo-500 text-lg font-semibold">Home</a>
+        <a href="#" class="text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100">Features</a>
+        <a href="#" class="text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100">Pricing</a>
+        <a href="#" class="text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100">About</a>
+      </nav>
+      <!-- nav - end -->
+
+      <!-- buttons - start -->
+      <a href="#" class="hidden lg:inline-block bg-gray-200 hover:bg-gray-300 focus-visible:ring ring-indigo-300 text-gray-500 active:text-gray-700 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3">Contact Sales</a>
+
+      <button type="button" class="inline-flex items-center lg:hidden bg-gray-200 hover:bg-gray-300 focus-visible:ring ring-indigo-300 text-gray-500 active:text-gray-700 text-sm md:text-base font-semibold rounded-lg gap-2 px-2.5 py-2">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" />
+        </svg>
+
+        Menu
+      </button>
+      <!-- buttons - end -->
+    </header>
+
+    <section class="min-h-96 flex justify-center items-center flex-1 shrink-0 bg-gray-100 overflow-hidden shadow-lg rounded-lg relative py-16 md:py-20 xl:py-48">
+      <!-- image - start -->
+      <img src="https://images.unsplash.com/photo-1618004652321-13a63e576b80?auto=format&q=75&fit=crop&w=1500" loading="lazy" alt="Photo by Fakurian Design" class="w-full h-full object-cover object-center absolute inset-0" />
+      <!-- image - end -->
+
+      <!-- overlay - start -->
+      <div class="bg-indigo-500 mix-blend-multiply absolute inset-0"></div>
+      <!-- overlay - end -->
+
+      <!-- text start -->
+      <div class="sm:max-w-xl flex flex-col items-center relative p-4">
+        <p class="text-indigo-200 text-lg sm:text-xl text-center mb-4 md:mb-8">Very proud to introduce</p>
+        <h1 class="text-white text-4xl sm:text-5xl md:text-6xl font-bold text-center mb-8 md:mb-12">Revolutionary way to build the web</h1>
+
+        <div class="w-full flex flex-col sm:flex-row sm:justify-center gap-2.5">
+          <a href="#" class="inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3">Start now</a>
+
+          <a href="#" class="inline-block bg-gray-200 hover:bg-gray-300 focus-visible:ring ring-indigo-300 text-gray-500 active:text-gray-700 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3">Take tour</a>
+        </div>
+      </div>
+      <!-- text end -->
+    </section>
+  </div>
+</div>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -1,59 +1,24 @@
-<div class="bg-white pb-6 sm:pb-8 lg:pb-12">
+<div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
-    <header class="flex justify-between items-center py-4 md:py-8 mb-4">
-      <!-- logo - start -->
-      <a href="/" class="inline-flex items-center text-black-800 text-2xl md:text-3xl font-bold gap-2.5" aria-label="logo">
-        <svg width="95" height="94" viewBox="0 0 95 94" class="w-6 h-auto text-indigo-500" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-          <path d="M96 0V47L48 94H0V47L48 0H96Z" />
-        </svg>
+    <!-- text - start -->
+    <div class="mb-10 md:mb-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">Gallery</h2>
 
-        <%= @graduation_album.title %>
-      </a>
-      <!-- logo - end -->
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">This is a section of some simple filler text, also known as placeholder text. It shares some characteristics of a real written text but is random or otherwise generated.</p>
+    </div>
+    <!-- text - end -->
 
-      <!-- nav - start -->
-      <nav class="hidden lg:flex gap-12">
-        <a href="#" class="text-indigo-500 text-lg font-semibold">Home</a>
-        <a href="#" class="text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100">Features</a>
-        <a href="#" class="text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100">Pricing</a>
-        <a href="#" class="text-gray-600 hover:text-indigo-500 active:text-indigo-700 text-lg font-semibold transition duration-100">About</a>
-      </nav>
-      <!-- nav - end -->
-
-      <!-- buttons - start -->
-      <a href="#" class="hidden lg:inline-block bg-gray-200 hover:bg-gray-300 focus-visible:ring ring-indigo-300 text-gray-500 active:text-gray-700 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3">Contact Sales</a>
-
-      <button type="button" class="inline-flex items-center lg:hidden bg-gray-200 hover:bg-gray-300 focus-visible:ring ring-indigo-300 text-gray-500 active:text-gray-700 text-sm md:text-base font-semibold rounded-lg gap-2 px-2.5 py-2">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h6a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" />
-        </svg>
-
-        Menu
-      </button>
-      <!-- buttons - end -->
-    </header>
-
-    <section class="min-h-96 flex justify-center items-center flex-1 shrink-0 bg-gray-100 overflow-hidden shadow-lg rounded-lg relative py-16 md:py-20 xl:py-48">
-      <!-- image - start -->
-      <img src="https://images.unsplash.com/photo-1618004652321-13a63e576b80?auto=format&q=75&fit=crop&w=1500" loading="lazy" alt="Photo by Fakurian Design" class="w-full h-full object-cover object-center absolute inset-0" />
-      <!-- image - end -->
-
-      <!-- overlay - start -->
-      <div class="bg-indigo-500 mix-blend-multiply absolute inset-0"></div>
-      <!-- overlay - end -->
-
-      <!-- text start -->
-      <div class="sm:max-w-xl flex flex-col items-center relative p-4">
-        <p class="text-indigo-200 text-lg sm:text-xl text-center mb-4 md:mb-8">Very proud to introduce</p>
-        <h1 class="text-white text-4xl sm:text-5xl md:text-6xl font-bold text-center mb-8 md:mb-12">Revolutionary way to build the web</h1>
-
-        <div class="w-full flex flex-col sm:flex-row sm:justify-center gap-2.5">
-          <a href="#" class="inline-block bg-indigo-500 hover:bg-indigo-600 active:bg-indigo-700 focus-visible:ring ring-indigo-300 text-white text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3">Start now</a>
-
-          <a href="#" class="inline-block bg-gray-200 hover:bg-gray-300 focus-visible:ring ring-indigo-300 text-gray-500 active:text-gray-700 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3">Take tour</a>
-        </div>
-      </div>
-      <!-- text end -->
-    </section>
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 md:gap-6 xl:gap-8">
+      <% if @graduation_album %>
+        <% @graduation_album.photos.each do |photo| %> 
+          <!-- image - start -->
+          <a href="#" class="group h-48 md:h-96 flex justify-end items-end bg-gray-100 overflow-hidden rounded-lg shadow-lg relative">
+            <%= image_tag photo.to_s, class:"w-full h-full object-cover object-center absolute inset-0 group-hover:scale-110 transition duration-200" %>
+            <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
+          </a>
+          <!-- image - end -->
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -4,23 +4,9 @@
       <a class="btn btn-ghost normal-case text-xl">Web卒アル</a>
     </div>
     <div class="flex-none">
-      <div class="dropdown dropdown-end">
-        <label tabindex="0" class="btn btn-ghost btn-circle">
-          <div class="indicator">
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z" /></svg>
-            <span class="badge badge-sm indicator-item">8</span>
-          </div>
-        </label>
-        <div tabindex="0" class="mt-3 card card-compact dropdown-content w-52 bg-base-100 shadow">
-          <div class="card-body">
-            <span class="font-bold text-lg">Item</span>
-            <span class="text-info">Subtotal: $999</span>
-            <div class="card-actions">
-              <button class="btn btn-primary btn-block">View cart</button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <button class="btn btn-link">
+        <%= link_to 'アルバム作成', new_graduation_album_path %>
+      </button>
       <div class="dropdown dropdown-end" id='profile'>
         <label tabindex="0" class="btn btn-ghost btn-circle avatar">
           <div class="w-10 rounded-full">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,3 +8,6 @@ ja:
         password: 'パスワード'
         password_confirmation: 'パスワード確認'
         name: '名前'
+      graduation_album:
+        album_name: 'アルバム名'
+        title: 'タイトル'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -11,3 +11,4 @@ ja:
       graduation_album:
         album_name: 'アルバム名'
         title: 'タイトル'
+        photos: '写真'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,5 @@ Rails.application.routes.draw do
   end
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root 'welcome_pages#top'
+  resources :graduation_albums
 end

--- a/db/migrate/20220623100133_create_graduation_albums.rb
+++ b/db/migrate/20220623100133_create_graduation_albums.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateGraduationAlbums < ActiveRecord::Migration[6.1]
   def change
     create_table :graduation_albums do |t|

--- a/db/migrate/20220623100133_create_graduation_albums.rb
+++ b/db/migrate/20220623100133_create_graduation_albums.rb
@@ -1,0 +1,11 @@
+class CreateGraduationAlbums < ActiveRecord::Migration[6.1]
+  def change
+    create_table :graduation_albums do |t|
+      t.string :title, null: false
+      t.string :album_name, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220623163002_add_photos_to_graduation_albums.rb
+++ b/db/migrate/20220623163002_add_photos_to_graduation_albums.rb
@@ -1,0 +1,5 @@
+class AddPhotosToGraduationAlbums < ActiveRecord::Migration[6.1]
+  def change
+    add_column :graduation_albums, :photos, :json
+  end
+end

--- a/db/migrate/20220623163002_add_photos_to_graduation_albums.rb
+++ b/db/migrate/20220623163002_add_photos_to_graduation_albums.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPhotosToGraduationAlbums < ActiveRecord::Migration[6.1]
   def change
     add_column :graduation_albums, :photos, :json

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_100133) do
+ActiveRecord::Schema.define(version: 2022_06_23_163002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2022_06_23_100133) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.json "photos"
     t.index ["user_id"], name: "index_graduation_albums_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,33 +12,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_163002) do
-
+ActiveRecord::Schema.define(version: 20_220_623_163_002) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "graduation_albums", force: :cascade do |t|
-    t.string "title", null: false
-    t.string "album_name", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.json "photos"
-    t.index ["user_id"], name: "index_graduation_albums_on_user_id"
+  create_table 'graduation_albums', force: :cascade do |t|
+    t.string 'title', null: false
+    t.string 'album_name', null: false
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.json 'photos'
+    t.index ['user_id'], name: 'index_graduation_albums_on_user_id'
   end
 
-  create_table "users", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "email", default: "", null: false
-    t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  create_table 'users', force: :cascade do |t|
+    t.string 'name', null: false
+    t.string 'email', default: '', null: false
+    t.string 'encrypted_password', default: '', null: false
+    t.string 'reset_password_token'
+    t.datetime 'reset_password_sent_at'
+    t.datetime 'remember_created_at'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['email'], name: 'index_users_on_email', unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end
 
-  add_foreign_key "graduation_albums", "users"
+  add_foreign_key 'graduation_albums', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,20 +10,32 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_220_621_104_735) do
-  # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+ActiveRecord::Schema.define(version: 2022_06_23_100133) do
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'name', null: false
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', precision: 6, null: false
-    t.datetime 'updated_at', precision: 6, null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "graduation_albums", force: :cascade do |t|
+    t.string "title", null: false
+    t.string "album_name", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_graduation_albums_on_user_id"
   end
+
+  create_table "users", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  add_foreign_key "graduation_albums", "users"
 end

--- a/spec/factories/graduation_album.rb
+++ b/spec/factories/graduation_album.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :graduation_album do
-		sequence(:album_name) { |n| "album_name_#{n}" }
+    sequence(:album_name) { |n| "album_name_#{n}" }
     sequence(:title) { |n| "title#{n}" }
     user
   end

--- a/spec/factories/graduation_album.rb
+++ b/spec/factories/graduation_album.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :graduation_album do
+		sequence(:album_name) { |n| "album_name_#{n}" }
+    sequence(:title) { |n| "title#{n}" }
+    user
+  end
+end

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: graduation_albums
@@ -23,7 +25,7 @@ require 'rails_helper'
 RSpec.describe GraduationAlbum, type: :model do
   describe 'バリデーション' do
     it 'アルバム名、タイトルが存在し、どちらも255字以内の場合有効であること' do
-			graduation_album = build(:graduation_album)
+      graduation_album = build(:graduation_album)
       expect(graduation_album).to be_valid
       expect(graduation_album.errors).to be_empty
     end
@@ -31,7 +33,7 @@ RSpec.describe GraduationAlbum, type: :model do
     it 'アルバム名が無い場合不正であること' do
       graduation_album_without_album_name = build(:graduation_album, album_name: nil)
       expect(graduation_album_without_album_name).to be_invalid
-      expect(graduation_album_without_album_name.errors[:album_name]).to eq ['を入力してください'] 
+      expect(graduation_album_without_album_name.errors[:album_name]).to eq ['を入力してください']
     end
 
     it 'タイトルが無い場合不正であること' do

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe GraduationAlbum, type: :model do
+  describe 'バリデーション' do
+    it 'アルバム名、タイトルが存在し、どちらも255字以内の場合有効であること' do
+			graduation_album = build(:graduation_album)
+      expect(graduation_album).to be_valid
+      expect(graduation_album.errors).to be_empty
+    end
+
+    it 'アルバム名が無い場合不正であること' do
+      graduation_album_without_album_name = build(:graduation_album, album_name: nil)
+      expect(graduation_album_without_album_name).to be_invalid
+      expect(graduation_album_without_album_name.errors[:album_name]).to eq ['を入力してください'] 
+    end
+
+    it 'タイトルが無い場合不正であること' do
+      graduation_album_without_title = build(:graduation_album, title: nil)
+      expect(graduation_album_without_title).to be_invalid
+      expect(graduation_album_without_title.errors[:title]).to eq ['を入力してください']
+    end
+
+    it 'アルバム名が255文字の場合有効であること' do
+      graduation_album_with_255_character_album_name = build(:graduation_album, album_name: 'a' * 255)
+      expect(graduation_album_with_255_character_album_name).to be_valid
+      expect(graduation_album_with_255_character_album_name.errors).to be_empty
+    end
+
+    it 'アルバム名が256文字の場合不正であること' do
+      graduation_album_with_256_character_album_name = build(:graduation_album, album_name: 'a' * 256)
+      expect(graduation_album_with_256_character_album_name).to be_invalid
+      expect(graduation_album_with_256_character_album_name.errors[:album_name]).to eq ['は255文字以内で入力してください']
+    end
+
+    it 'タイトルが255文字の場合有効であること' do
+      graduation_album_with_255_character_title = build(:graduation_album, title: 'a' * 255)
+      expect(graduation_album_with_255_character_title).to be_valid
+      expect(graduation_album_with_255_character_title.errors).to be_empty
+    end
+
+    it 'タイトルが256文字の場合不正であること' do
+      graduation_album_with_256_character_title = build(:graduation_album, title: 'a' * 256)
+      expect(graduation_album_with_256_character_title).to be_invalid
+      expect(graduation_album_with_256_character_title.errors[:title]).to eq ['は255文字以内で入力してください']
+    end
+  end
+end

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: graduation_albums
+#
+#  id         :bigint           not null, primary key
+#  album_name :string           not null
+#  photos     :json
+#  title      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint           not null
+#
+# Indexes
+#
+#  index_graduation_albums_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 require 'rails_helper'
 
 RSpec.describe GraduationAlbum, type: :model do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,32 +32,32 @@ RSpec.describe User, type: :model do
     it 'メールアドレスが無い場合不正であること' do
       user_without_email = build(:user, email: nil)
       expect(user_without_email).to be_invalid
-      expect(user_without_email.errors[:email]).to include('を入力してください')
+      expect(user_without_email.errors[:email]).to eq ['を入力してください']
     end
 
     it 'メールアドレスがユニークでなければ不正であること' do
       user_one = create(:user)
       user_another = build(:user, email: user_one.email)
       expect(user_another).to be_invalid
-      expect(user_another.errors[:email]).to include('はすでに存在します')
+      expect(user_another.errors[:email]).to eq ['はすでに存在します']
     end
 
     it 'パスワードが無い場合不正であること' do
       user_without_password = build(:user, password: nil)
       expect(user_without_password).to be_invalid
-      expect(user_without_password.errors[:password]).to include('を入力してください')
+      expect(user_without_password.errors[:password]).to eq ['を入力してください']
     end
 
     it 'パスワードが6字以上の場合不正であること' do
       user_with_two_character_password = build(:user, password: 'ab')
       expect(user_with_two_character_password).to be_invalid
-      expect(user_with_two_character_password.errors[:password]).to include('は6文字以上で入力してください')
+      expect(user_with_two_character_password.errors[:password]).to eq ['は6文字以上で入力してください']
     end
 
     it '名前が無い場合不正であること' do
       user_without_name = build(:user, name: nil)
       expect(user_without_name).to be_invalid
-      expect(user_without_name.errors[:name]).to include('を入力してください')
+      expect(user_without_name.errors[:name]).to eq ['を入力してください']
     end
 
     it '名前が255文字の場合有効であること' do

--- a/spec/system/graduation_albums_spec.rb
+++ b/spec/system/graduation_albums_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe "GraduationAlbums", type: :system do
   let(:user){ create(:user) }
   let(:graduation_album){ create(:graduation_album, user: user) }
+  let(:graduation_album_by_others) { create(:graduation_album) }
   describe 'ログイン後' do
     before do
       login_as(user)
@@ -45,38 +46,43 @@ RSpec.describe "GraduationAlbums", type: :system do
   
     describe 'アルバムの編集' do
       context 'フォームの入力値が正常' do
-        fit 'アルバムの編集が成功する' do
+        it 'アルバムの編集が成功する' do
           graduation_album
           visit edit_graduation_album_path(graduation_album)
           fill_in 'アルバム名', with: 'after_edit'
           click_button '作成する'
           expect(page).to have_content '編集に成功しました'
           expect(current_path).to eq graduation_albums_path
-          visit graduation_albums_path
-          expect(page).to have_content 'after_edit'
         end
       end
 
-      context 'フォームの入力値が不正' do
-        fit 'アルバムの新規作成が失敗する' do
+      context 'タイトルがnil' do
+        it 'アルバムの編集が失敗する' do
           graduation_album
           visit edit_graduation_album_path(graduation_album)
           fill_in 'タイトル', with: nil
           fill_in 'アルバム名', with: 'test'
           click_button '作成する'
-          expect(page).to have_content '作成に失敗しました'
-          expect(current_path).to eq edit_graduation_album_path(graduation_album)
+          expect(current_path).to eq graduation_album_path(graduation_album)
+        end
+      end
+
+      context 'タイトルがnil' do
+        it 'アルバムの編集が失敗する' do
+          graduation_album
+          visit edit_graduation_album_path(graduation_album)
+          fill_in 'タイトル', with: 'test'
+          fill_in 'アルバム名', with: nil
+          click_button '作成する'
+          expect(current_path).to eq graduation_album_path(graduation_album)
         end
       end
 
       context '他のユーザーがアルバムを編集' do
         it 'アルバムの編集が失敗する' do
-          visit new_graduation_album_path
-          fill_in 'タイトル', with: 'test'
-          fill_in 'アルバム名', with: 'test'
-          click_button '作成する'
-          expect(page).to have_content '作成に成功しました'
-          expect(current_path).to eq graduation_albums_path
+          graduation_album_by_others
+          visit graduation_albums_path
+          expect(page).not_to have_content '編集'
         end
       end
     end
@@ -84,27 +90,20 @@ RSpec.describe "GraduationAlbums", type: :system do
     describe 'アルバムの削除' do
       context '作成ユーザーが自分のアルバムを削除' do
         it 'アルバムの削除が成功する' do
-          visit '/users/new'
-          fill_in '名前', with: 'test_name'
-          fill_in 'メールアドレス', with: 'test@example.com'
-          fill_in 'パスワード', with: 'password'
-          fill_in 'パスワード確認', with: 'password'
-          click_button '登録'
-          expect(page).to have_content 'ユーザー登録が完了'
-          expect(current_path).to eq login_path
+          graduation_album
+          visit graduation_albums_path
+          page.accept_confirm do
+            click_on :delete_button
+          end
+          expect(current_path).to eq graduation_albums_path
         end
       end
 
       context '他のユーザーがアルバムを削除' do
         it 'アルバムの削除が失敗する' do
-          visit '/users/new'
-          fill_in '名前', with: 'test_name'
-          fill_in 'メールアドレス', with: 'test@example.com'
-          fill_in 'パスワード', with: 'password'
-          fill_in 'パスワード確認', with: 'password'
-          click_button '登録'
-          expect(page).to have_content 'ユーザー登録が完了'
-          expect(current_path).to eq login_path
+          graduation_album_by_others
+          visit graduation_albums_path
+          expect(page).not_to have_content '削除'
         end
       end
     end

--- a/spec/system/graduation_albums_spec.rb
+++ b/spec/system/graduation_albums_spec.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "GraduationAlbums", type: :system do
-  let(:user){ create(:user) }
-  let(:graduation_album){ create(:graduation_album, user: user) }
+RSpec.describe 'GraduationAlbums', type: :system do
+  let(:user) { create(:user) }
+  let(:graduation_album) { create(:graduation_album, user:) }
   let(:graduation_album_by_others) { create(:graduation_album) }
   describe 'ログイン後' do
     before do
@@ -43,7 +45,7 @@ RSpec.describe "GraduationAlbums", type: :system do
         end
       end
     end
-  
+
     describe 'アルバムの編集' do
       context 'フォームの入力値が正常' do
         it 'アルバムの編集が成功する' do
@@ -86,7 +88,7 @@ RSpec.describe "GraduationAlbums", type: :system do
         end
       end
     end
-  
+
     describe 'アルバムの削除' do
       context '作成ユーザーが自分のアルバムを削除' do
         it 'アルバムの削除が成功する' do

--- a/spec/system/graduation_albums_spec.rb
+++ b/spec/system/graduation_albums_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+RSpec.describe "GraduationAlbums", type: :system do
+  let(:user){ create(:user) }
+  let(:graduation_album){ create(:graduation_album, user: user) }
+  describe 'ログイン後' do
+    before do
+      login_as(user)
+    end
+
+    describe 'アルバムの新規作成' do
+      context 'フォームの入力値が正常' do
+        it 'アルバムの新規作成が成功する' do
+          visit new_graduation_album_path
+          fill_in 'タイトル', with: 'test'
+          fill_in 'アルバム名', with: 'test'
+          click_button '作成する'
+          expect(page).to have_content '作成に成功しました'
+          expect(current_path).to eq graduation_albums_path
+        end
+      end
+
+      context 'タイトルが未入力' do
+        it 'アルバムの新規作成が失敗する' do
+          visit new_graduation_album_path
+          fill_in 'タイトル', with: nil
+          fill_in 'アルバム名', with: 'test'
+          click_button '作成する'
+          expect(page).to have_content '作成に失敗しました'
+          expect(current_path).to eq graduation_albums_path
+        end
+      end
+
+      context 'アルバム名が未入力' do
+        it 'アルバムの新規作成が失敗する' do
+          visit new_graduation_album_path
+          fill_in 'タイトル', with: 'test'
+          fill_in 'アルバム名', with: nil
+          click_button '作成する'
+          expect(page).to have_content '作成に失敗しました'
+          expect(current_path).to eq graduation_albums_path
+        end
+      end
+    end
+  
+    describe 'アルバムの編集' do
+      context 'フォームの入力値が正常' do
+        fit 'アルバムの編集が成功する' do
+          graduation_album
+          visit edit_graduation_album_path(graduation_album)
+          fill_in 'アルバム名', with: 'after_edit'
+          click_button '作成する'
+          expect(page).to have_content '編集に成功しました'
+          expect(current_path).to eq graduation_albums_path
+          visit graduation_albums_path
+          expect(page).to have_content 'after_edit'
+        end
+      end
+
+      context 'フォームの入力値が不正' do
+        fit 'アルバムの新規作成が失敗する' do
+          graduation_album
+          visit edit_graduation_album_path(graduation_album)
+          fill_in 'タイトル', with: nil
+          fill_in 'アルバム名', with: 'test'
+          click_button '作成する'
+          expect(page).to have_content '作成に失敗しました'
+          expect(current_path).to eq edit_graduation_album_path(graduation_album)
+        end
+      end
+
+      context '他のユーザーがアルバムを編集' do
+        it 'アルバムの編集が失敗する' do
+          visit new_graduation_album_path
+          fill_in 'タイトル', with: 'test'
+          fill_in 'アルバム名', with: 'test'
+          click_button '作成する'
+          expect(page).to have_content '作成に成功しました'
+          expect(current_path).to eq graduation_albums_path
+        end
+      end
+    end
+  
+    describe 'アルバムの削除' do
+      context '作成ユーザーが自分のアルバムを削除' do
+        it 'アルバムの削除が成功する' do
+          visit '/users/new'
+          fill_in '名前', with: 'test_name'
+          fill_in 'メールアドレス', with: 'test@example.com'
+          fill_in 'パスワード', with: 'password'
+          fill_in 'パスワード確認', with: 'password'
+          click_button '登録'
+          expect(page).to have_content 'ユーザー登録が完了'
+          expect(current_path).to eq login_path
+        end
+      end
+
+      context '他のユーザーがアルバムを削除' do
+        it 'アルバムの削除が失敗する' do
+          visit '/users/new'
+          fill_in '名前', with: 'test_name'
+          fill_in 'メールアドレス', with: 'test@example.com'
+          fill_in 'パスワード', with: 'password'
+          fill_in 'パスワード確認', with: 'password'
+          click_button '登録'
+          expect(page).to have_content 'ユーザー登録が完了'
+          expect(current_path).to eq login_path
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 関連するissue
close #19 

## 概要
以下を実行しました。

- 追加機能のRspecを実装
- アルバムの投稿、編集、削除機能
- carriewaveを使用した写真の複数枚投稿機能
- カラムにオーナーidを追加してそのユーザーだけが削除を行えるようになる
- 編集権限もオーナーだけでいいような気がする
- 日本語化を行う
- ヘッダーに新規登録へのリンクを追加
- 編集と削除を作成者に限定
- 作成・編集・削除はログイン後に限定


## 確認事項

- [x] 実装機能にRspecが書かれているか
- [x] 画像は複数枚投稿できるか
- [x] rubocopの実行

## 確認方法
graduation_albums_pathに遷移してもらい新規作成ボタンをクリックし、CRUD機能を実行することで確認できます。


## 懸念点
- #22
- #23
- #24

## 参考記事
[公式wiki](https://github.com/carrierwaveuploader/carrierwave)