### PR TITLE
投稿フォームの修正

### DIFF
--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -92,7 +92,7 @@ class GraduationAlbumsController < ApplicationController
   private
 
   def graduation_album_params
-    params.require(:graduation_album).permit(:album_name, :title, { photos: [] }, { user_ids: [] })
+    params.require(:graduation_album).permit(:album_name, { photos: [] }, { user_ids: [] })
   end
 
   def set_graduation_album

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -7,7 +7,6 @@
 #  id         :bigint           not null, primary key
 #  album_name :string           not null
 #  photos     :json
-#  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null
@@ -32,5 +31,5 @@ class GraduationAlbum < ApplicationRecord
   has_many :suprise_messages, dependent: :destroy
   has_many :photo_paths, dependent: :destroy
 
-  validates :title, :album_name, presence: true, length: { maximum: 255 }
+  validates :album_name, presence: true, length: { maximum: 255 }
 end

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -3,15 +3,15 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :title, class: "text-sm block"%>
-      <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "タイトル" %>
     </div>
     <div class="mb-8">
       <%= f.label :description, class: "text-sm block"%>
-      <%= f.text_field :description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "詳細" %>
     </div>
     <div class="mb-8">
       <%= f.label :event_date, class: "text-sm block"%>
-      <%= f.date_field :event_date, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.date_field :event_date, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "日付" %>
     </div>
     <div class="mb-8">
       <%= f.label :event_photos, class: "text-sm block"%>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -3,15 +3,15 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :title, class: "text-sm block"%>
-      <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "タイトル" %>
     </div>
     <div class="mb-8">
       <%= f.label :description, class: "text-sm block"%>
-      <%= f.text_field :description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "詳細" %>
     </div>
     <div class="mb-8">
       <%= f.label :event_date, class: "text-sm block"%>
-      <%= f.date_field :event_date, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.date_field :event_date, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "日付" %>
     </div>
     <div class="mb-8">
       <%= f.label :event_photos, class: "text-sm block"%>

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -2,12 +2,8 @@
   <%= form_with model: graduation_album, class:"w-10/12 mx-auto md:max-w-md", local: true do |f| %>
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
-      <%= f.label :title, class: "text-sm block"%>
-      <%= f.text_field :title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
-    </div>
-    <div class="mb-8">
       <%= f.label :album_name, class: "text-sm block"%>
-      <%= f.text_field :album_name, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :album_name, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "アルバム名" %>
     </div>
     <div class="mb-8">
       <%= f.label :photos, class: "text-sm block"%>

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -14,8 +14,12 @@
       <%= f.file_field :photos, multiple: true, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50' %>
     </div>
     <div class="mb-8">
-      <%= f.label :user_ids, class: "text-sm block"%>
-      <%= f.collection_check_boxes :user_ids, current_user.followings, :id, :name %>
+      <% unless current_user.followings.count == 0 %>
+        <%= f.label :user_ids, 'メンバー', class: "text-sm block"%>
+        <%= f.collection_check_boxes :user_ids, current_user.followings, :id, :name %>
+      <% else %>
+        フォロワーがいません
+      <% end %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/rank_choices/edit.html.erb
+++ b/app/views/rank_choices/edit.html.erb
@@ -3,7 +3,7 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :content, class: "text-sm block"%>
-      <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "選択肢" %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/rank_choices/new.html.erb
+++ b/app/views/rank_choices/new.html.erb
@@ -3,7 +3,7 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :content, class: "text-sm block"%>
-      <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "選択肢" %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/ranks/edit.html.erb
+++ b/app/views/ranks/edit.html.erb
@@ -3,11 +3,11 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :rank_title, class: "text-sm block"%>
-      <%= f.text_field :rank_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :rank_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "タイトル" %>
     </div>
     <div class="mb-8">
       <%= f.label :rank_description, class: "text-sm block"%>
-      <%= f.text_field :rank_description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :rank_description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "詳細" %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/ranks/new.html.erb
+++ b/app/views/ranks/new.html.erb
@@ -3,11 +3,11 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :rank_title, class: "text-sm block"%>
-      <%= f.text_field :rank_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :rank_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "タイトル" %>
     </div>
     <div class="mb-8">
       <%= f.label :rank_description, class: "text-sm block"%>
-      <%= f.text_field :rank_description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :rank_description, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "詳細" %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/suprise_messages/edit.html.erb
+++ b/app/views/suprise_messages/edit.html.erb
@@ -3,15 +3,15 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :suprise_title, class: "text-sm block"%>
-      <%= f.text_field :suprise_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :suprise_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "タイトル" %>
     </div>
     <div class="mb-8">
       <%= f.label :suprise_message, class: "text-sm block"%>
-      <%= f.text_field :suprise_message, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :suprise_message, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "メッセージ" %>
     </div>
     <div class="mb-8">
       <%= f.label :suprise_time, class: "text-sm block"%>
-      <%= f.date_field :suprise_time, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.date_field :suprise_time, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "日付" %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/suprise_messages/new.html.erb
+++ b/app/views/suprise_messages/new.html.erb
@@ -3,15 +3,15 @@
   <%= render "shared/error_messages", object: f.object %>
     <div class="mb-8">
       <%= f.label :suprise_title, class: "text-sm block"%>
-      <%= f.text_field :suprise_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :suprise_title, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "タイトル" %>
     </div>
     <div class="mb-8">
       <%= f.label :suprise_message, class: "text-sm block"%>
-      <%= f.text_field :suprise_message, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.text_field :suprise_message, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "メッセージ" %>
     </div>
     <div class="mb-8">
       <%= f.label :suprise_time, class: "text-sm block"%>
-      <%= f.date_field :suprise_time, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "山田太郎" %>
+      <%= f.date_field :suprise_time, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "日付" %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -26,3 +26,7 @@ ja:
         rank_description: '詳細'
       rank_choice:
         content: '選択肢'
+      suprise_message:
+        suprise_title: 'タイトル'
+        suprise_message: 'メッセージ'
+        suprise_time: 'サプライズ実行日'

--- a/db/migrate/20220706080954_remove_title_from_graduation_albums.rb
+++ b/db/migrate/20220706080954_remove_title_from_graduation_albums.rb
@@ -1,0 +1,9 @@
+class RemoveTitleFromGraduationAlbums < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :graduation_albums, :title
+  end
+
+  def down
+    add_column :graduation_albums, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_04_124335) do
+ActiveRecord::Schema.define(version: 2022_07_06_080954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,7 +49,6 @@ ActiveRecord::Schema.define(version: 2022_07_04_124335) do
   end
 
   create_table "graduation_albums", force: :cascade do |t|
-    t.string "title", null: false
     t.string "album_name", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/graduation_album.rb
+++ b/spec/factories/graduation_album.rb
@@ -3,7 +3,6 @@
 FactoryBot.define do
   factory :graduation_album do
     sequence(:album_name) { |n| "album_name_#{n}" }
-    sequence(:title) { |n| "title#{n}" }
     user
   end
 end

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -7,7 +7,6 @@
 #  id         :bigint           not null, primary key
 #  album_name :string           not null
 #  photos     :json
-#  title      :string           not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  user_id    :bigint           not null
@@ -23,8 +22,8 @@
 require 'rails_helper'
 
 RSpec.describe GraduationAlbum, type: :model do
-  describe 'バリデーション' do
-    it 'アルバム名、タイトルが存在し、どちらも255字以内の場合有効であること' do
+  fdescribe 'バリデーション' do
+    it 'アルバム名が存在し、どちらも255字以内の場合有効であること' do
       graduation_album = build(:graduation_album)
       expect(graduation_album).to be_valid
       expect(graduation_album.errors).to be_empty
@@ -34,12 +33,6 @@ RSpec.describe GraduationAlbum, type: :model do
       graduation_album_without_album_name = build(:graduation_album, album_name: nil)
       expect(graduation_album_without_album_name).to be_invalid
       expect(graduation_album_without_album_name.errors[:album_name]).to eq ['を入力してください']
-    end
-
-    it 'タイトルが無い場合不正であること' do
-      graduation_album_without_title = build(:graduation_album, title: nil)
-      expect(graduation_album_without_title).to be_invalid
-      expect(graduation_album_without_title.errors[:title]).to eq ['を入力してください']
     end
 
     it 'アルバム名が255文字の場合有効であること' do
@@ -52,18 +45,6 @@ RSpec.describe GraduationAlbum, type: :model do
       graduation_album_with_256_character_album_name = build(:graduation_album, album_name: 'a' * 256)
       expect(graduation_album_with_256_character_album_name).to be_invalid
       expect(graduation_album_with_256_character_album_name.errors[:album_name]).to eq ['は255文字以内で入力してください']
-    end
-
-    it 'タイトルが255文字の場合有効であること' do
-      graduation_album_with_255_character_title = build(:graduation_album, title: 'a' * 255)
-      expect(graduation_album_with_255_character_title).to be_valid
-      expect(graduation_album_with_255_character_title.errors).to be_empty
-    end
-
-    it 'タイトルが256文字の場合不正であること' do
-      graduation_album_with_256_character_title = build(:graduation_album, title: 'a' * 256)
-      expect(graduation_album_with_256_character_title).to be_invalid
-      expect(graduation_album_with_256_character_title.errors[:title]).to eq ['は255文字以内で入力してください']
     end
   end
 end

--- a/spec/system/graduation_albums_spec.rb
+++ b/spec/system/graduation_albums_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe 'GraduationAlbums', type: :system do
       context 'フォームの入力値が正常' do
         it 'アルバムの新規作成が成功する' do
           visit new_graduation_album_path
-          fill_in 'タイトル', with: 'test'
           fill_in 'アルバム名', with: 'test'
           click_button '作成する'
           expect(page).to have_content '作成に成功しました'
@@ -26,7 +25,6 @@ RSpec.describe 'GraduationAlbums', type: :system do
       context 'タイトルが未入力' do
         it 'アルバムの新規作成が失敗する' do
           visit new_graduation_album_path
-          fill_in 'タイトル', with: nil
           fill_in 'アルバム名', with: 'test'
           click_button '作成する'
           expect(page).to have_content '作成に失敗しました'
@@ -37,7 +35,6 @@ RSpec.describe 'GraduationAlbums', type: :system do
       context 'アルバム名が未入力' do
         it 'アルバムの新規作成が失敗する' do
           visit new_graduation_album_path
-          fill_in 'タイトル', with: 'test'
           fill_in 'アルバム名', with: nil
           click_button '作成する'
           expect(page).to have_content '作成に失敗しました'
@@ -58,22 +55,10 @@ RSpec.describe 'GraduationAlbums', type: :system do
         end
       end
 
-      context 'タイトルがnil' do
+      context 'アルバム名がnil' do
         it 'アルバムの編集が失敗する' do
           graduation_album
           visit edit_graduation_album_path(graduation_album)
-          fill_in 'タイトル', with: nil
-          fill_in 'アルバム名', with: 'test'
-          click_button '作成する'
-          expect(current_path).to eq graduation_album_path(graduation_album)
-        end
-      end
-
-      context 'タイトルがnil' do
-        it 'アルバムの編集が失敗する' do
-          graduation_album
-          visit edit_graduation_album_path(graduation_album)
-          fill_in 'タイトル', with: 'test'
           fill_in 'アルバム名', with: nil
           click_button '作成する'
           expect(current_path).to eq graduation_album_path(graduation_album)
@@ -94,7 +79,6 @@ RSpec.describe 'GraduationAlbums', type: :system do
         it 'アルバムの削除が成功する' do
           graduation_album
           visit new_graduation_album_path
-          fill_in 'タイトル', with: 'test'
           fill_in 'アルバム名', with: 'test'
           click_button '作成する'
           visit graduation_albums_path


### PR DESCRIPTION
## 関連するissue
close #55 

## 概要
以下を実行しました。

・GraduationAlbumモデルのtitleカラムを削除
・入力フォームのプレスホルダーの内容を修正
・SupriseMessageモデルの日本語化

## 確認事項
特になし

## 懸念点
特になし。

## 参考記事
特になし。