### PR TITLE
アルバム詳細画面のデザイン変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,5 @@ gem 'fog-aws'
 gem 'dotenv-rails'
 # aws_rekognition
 gem 'aws-sdk-rekognition'
+# 画像のサイズ調節
+gem 'mini_magick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,6 +423,7 @@ DEPENDENCIES
   fog-aws
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  mini_magick
   net-imap
   net-pop
   net-smtp

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link application.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,2 @@
+//= require swiper/swiper-bundle.min.js
+//= require swiper.js

--- a/app/assets/javascripts/swiper.js
+++ b/app/assets/javascripts/swiper.js
@@ -1,9 +1,43 @@
 document.addEventListener('DOMContentLoaded', function() { 
-  const swiper = new Swiper('.swiper', { 
-                 loop: true, 
-                   navigation: {
+  const mySwiper = new Swiper('.mySwiper', {
+  // Optional parameters
+  loop: true,
+  loopAdditionalSlides: 1,
+
+  //アニメーションで動くように設定
+  speed: 700,
+  autoplay: {
+    delay: 2000,
+    disableOnInteraction: false,
+  },
+
+  watchSlidesProgress: true,
+
+  // Navigation arrows
+  navigation: {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev',
   },
+
+  slidesPerView: 3,
+  spaceBetween: 30,
+  centeredSlides: true,
+  pagination: {
+    el: ".swiper-pagination",
+    clickable: true,
+  },
   })
+});
+
+document.addEventListener('DOMContentLoaded', function() { 
+  const loopSwiper = new Swiper('.loopSwiper', {
+  spaceBetween: 5,
+  loop: true, // ループ有効
+  slidesPerView: 5, // 一度に表示する枚数
+  speed: 8000, // ループの時間
+  allowTouchMove: false, // スワイプ無効
+  autoplay: {
+    delay: 0, // 途切れなくループ
+  },
+});
 });

--- a/app/assets/javascripts/swiper.js
+++ b/app/assets/javascripts/swiper.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', function() { 
+  const swiper = new Swiper('.swiper', { 
+                 loop: true, 
+                   navigation: {
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
+  },
+  })
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,3 +19,4 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import '@fortawesome/fontawesome-free/scss/regular';
 @import '@fortawesome/fontawesome-free/scss/brands';
 @import '@fortawesome/fontawesome-free/scss/v4-shims';
+@import 'swiper/swiper-bundle.min.css';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,3 +20,27 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import '@fortawesome/fontawesome-free/scss/brands';
 @import '@fortawesome/fontawesome-free/scss/v4-shims';
 @import 'swiper/swiper-bundle.min.css';
+
+#album-swiper {
+  height: 400px;
+}
+
+#album-swiper>img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+#loop-swiper {
+  height: 200px;
+}
+
+#loop-swiper>img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.swiper-wrapper {
+  transition-timing-function: linear;
+}

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -22,7 +22,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Answer < ApplicationRecord
+  belongs_to :rank_choice, counter_cache: true
   belongs_to :rank
-  belongs_to :rank_choice
   belongs_to :user
 end

--- a/app/models/rank_choice.rb
+++ b/app/models/rank_choice.rb
@@ -2,11 +2,12 @@
 #
 # Table name: rank_choices
 #
-#  id         :bigint           not null, primary key
-#  content    :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  rank_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  answers_count :integer          default(0)
+#  content       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  rank_id       :bigint           not null
 #
 # Indexes
 #

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -3,40 +3,23 @@
 class PhotoUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
   # storage :file
   storage :fog
 
-  # Override the directory where uploaded files will be stored.
-  # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
-  # end
-
   # Process files as they are uploaded:
-  # process scale: [200, 300]
-  #
-  # def scale(width, height)
-  #   # do something
-  # end
+  # ＃process resize_to_fit: [150, 150]
+# ＃
+  version :ablum_photo do
+    process resize_to_fit: [400, 500]
+  end
 
-  # Create different versions of your uploaded files:
-  # version :thumb do
-  #   process resize_to_fit: [50, 50]
-  # end
-
-  # Add an allowlist of extensions which are allowed to be uploaded.
-  # For images you might use something like this:
   def extension_allowlist
     %w[jpg jpeg gif png]
   end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,13 +1,37 @@
-<div class="card lg:card-side bg-base-100 my-6 shadow-xl">
-  <figure><img src="https://api.lorem.space/image/album?w=400&h=400" alt="Album"></figure>
-  <div class="card-body">
-    <h2 class="card-title"><%= link_to event.title, graduation_album_event_path(event.graduation_album, event)%></h2>
-    <p> <%= event.description %></p>
-    <div class="card-actions justify-end">
-      <% if current_user.own?(event) %>
-        <%= link_to '編集', edit_graduation_album_event_path(event.graduation_album, event), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
-        <%= link_to '削除', graduation_album_event_path(event.graduation_album, event), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-      <% end %>
+<li class="mb-10 ml-6">         
+    <span class="flex absolute -left-3 justify-center items-center w-10 h-10 bg-blue-200 rounded-full ring-8 ring-white dark:ring-gray-900 dark:bg-blue-900">
+        <i class="fa-solid fa-plane-departure"></i>
+    </span>
+    <h3 class="flex items-center mb-1 text-lg font-semibold text-gray-900 dark:text-white px-4 pt-2"><div class='text-right'><%= l event.event_date %></div></h3>
+    <div class="bg-white py-3 sm:py-4 lg:py-6">
+      <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
+        <div class="md:h-80 flex flex-col sm:flex-row bg-gray-200 rounded-lg overflow-hidden">
+          <!-- image - start -->
+          <div class="w-full sm:w-1/2 lg:w-2/5 h-48 sm:h-auto order-first sm:order-none bg-gray-300">
+            <%= link_to graduation_album_event_path(event.graduation_album, event) do %>
+              <%= image_tag event.event_photos.shuffle.first.to_s %>
+            <% end %>
+          </div>
+          <!-- image - end -->
+          <!-- content - start -->
+          <div class="w-full sm:w-1/2 lg:w-3/5 flex flex-col p-4 sm:p-8">
+            <h2 class="text-gray-800 text-xl md:text-2xl lg:text-4xl font-bold mb-4"><%= link_to event.title, graduation_album_event_path(event.graduation_album, event)%></h2>
+            <p class="max-w-md text-gray-600 mb-8"><%= event.description %></p>
+            <div class="mt-auto text-right">
+              <% if current_user.own?(event) %>
+                <%= link_to graduation_album_event_path(event.graduation_album, event), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 text-gray-800 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3" do%>
+                  <i class="fa-solid fa-trash-can fa-lg"></i>
+                <% end %>
+              <% end %>
+              <%= link_to '詳細へ', graduation_album_event_path(event.graduation_album, event), class: "inline-block bg-white hover:bg-gray-100 active:bg-gray-200 focus-visible:ring ring-indigo-300 text-gray-800 text-sm md:text-base font-semibold text-center rounded-lg outline-none transition duration-100 px-8 py-3" %>
+            </div>
+          </div>
+          <!-- content - end -->
+        </div>
+      </div>
     </div>
-  </div>
-</div>
+</li>
+
+
+  
+

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -2,5 +2,10 @@
   <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">思い出の行事</h2>
   <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">みんなとの楽しい思い出を共有しよう</p>
 </div>
-<%= render events %>
+<ol class="relative border-l border-gray-200 dark:border-gray-700">                  
+  <%= render events %>
+</ol>
+
+<div class='text-center'>
 <button class="btn btn-outline"><%= link_to 'イベントを作成', new_graduation_album_event_path(@graduation_album) %></button>
+</div>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -1,24 +1,28 @@
-<div class="bg-white py-6 sm:py-8 lg:py-12">
+<div class="bg-white py-3 sm:py-4 lg:py-6">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <!-- text - start -->
     <div class="mb-10 md:mb-16">
       <h1 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 underline"><%= @graduation_album.album_name %></h1>
-
-      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto"><%= @graduation_album.album_name%>へようこそ！コンテンツを増やしてアルバムを盛り上げよう</p>
-    </div>
-    <!-- text - end -->
-
-    <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 md:gap-6 xl:gap-8">
-      <% if @graduation_album.photos %>
-        <% @graduation_album.photos.each do |photo| %> 
-          <!-- image - start -->
-          <a href="#" class="group h-48 md:h-96 flex justify-end items-end bg-gray-100 overflow-hidden rounded-lg shadow-lg relative">
-            <%= image_tag photo.to_s, class:"w-full h-full object-cover object-center absolute inset-0 group-hover:scale-110 transition duration-200" %>
-            <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
-          </a>
-          <!-- image - end -->
-        <% end %>
-      <% end %>
+      <div class="bg-white py-3 sm:py-4 lg:py-6">
+        <div class=" px-4 md:px-8 mx-auto">
+          <% if @graduation_album.photos %>
+          <div class="swiper-container">
+              <div class="swiper mySwiper">
+                <div class="swiper-wrapper">
+                  <% @graduation_album.photos.each do |photo| %> 
+                    <%= image_tag photo.url(:ablum_photo), class:"swiper-slide rounded-lg", id:"album-swiper" %>
+                  <% end %>
+                </div><!-- .swiper-wrapper -->
+                                <div class="swiper-pagination"></div>
+                  <div class="swiper-button-prev">
+                  </div><!-- .swiper-button-prev -->
+                <div class="swiper-button-next">
+                </div><!-- .swiper-button-next -->
+              </div><!-- .swiper mySwiper -->
+          <% end %>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -40,10 +44,25 @@
       <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center pt-4 mb-4 md:mb-6 underline">メンバーからのメッセージ</h2>
     </div>
     <!-- text - end -->
+  </div>
+</div>
     <%if @message_for_everyones %>
-    <%= render 'message_for_everyones/message_for_everyones', { message_for_everyones: @message_for_everyones } %>
+      <%= render 'message_for_everyones/message_for_everyones', { message_for_everyones: @message_for_everyones } %>
     <% end %>
     <%= render 'message_for_everyones/form', { graduation_album: @graduation_album, message_for_everyone: @message_for_everyone } %>
+    <div class='pt-5'>
+    <% if @graduation_album.photos %>
+      <div class="swiper loopSwiper">
+        <div class="swiper-wrapper">
+          <% @graduation_album.photos.each do |photo| %> 
+            <%= image_tag photo.url(:ablum_photo), class:"swiper-slide rounded-lg", id:"loop-swiper" %>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+    </div>
+<div class="bg-white py-6 sm:py-8 lg:py-12">
+  <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
     <%= render 'events/events', { graduation_album: @graduation_album, events: @events } %>
     <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks } %>
     <%= render 'suprise_messages/suprise_messages', { graduation_album: @graduation_album, suprise_messages: @suprise_messages } %>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -13,11 +13,9 @@
                     <%= image_tag photo.url(:ablum_photo), class:"swiper-slide rounded-lg", id:"album-swiper" %>
                   <% end %>
                 </div><!-- .swiper-wrapper -->
-                                <div class="swiper-pagination"></div>
-                  <div class="swiper-button-prev">
-                  </div><!-- .swiper-button-prev -->
-                <div class="swiper-button-next">
-                </div><!-- .swiper-button-next -->
+                  <div class="swiper-pagination"></div>
+                  <div class="swiper-button-prev"></div>
+                <div class="swiper-button-next"></div>
               </div><!-- .swiper mySwiper -->
           <% end %>
           </div>
@@ -26,7 +24,6 @@
     </div>
   </div>
 </div>
-
 <!-- message for everyone -->
 <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 underline">メンバー</h2>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
@@ -44,27 +41,28 @@
       <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center pt-4 mb-4 md:mb-6 underline">メンバーからのメッセージ</h2>
     </div>
     <!-- text - end -->
-  </div>
-</div>
     <%if @message_for_everyones %>
       <%= render 'message_for_everyones/message_for_everyones', { message_for_everyones: @message_for_everyones } %>
     <% end %>
     <%= render 'message_for_everyones/form', { graduation_album: @graduation_album, message_for_everyone: @message_for_everyone } %>
-    <div class='pt-5'>
-    <% if @graduation_album.photos %>
-      <div class="swiper loopSwiper">
-        <div class="swiper-wrapper">
-          <% @graduation_album.photos.each do |photo| %> 
-            <%= image_tag photo.url(:ablum_photo), class:"swiper-slide rounded-lg", id:"loop-swiper" %>
-          <% end %>
-        </div>
+  </div>
+</div>
+    
+<div class='pt-5'>
+  <% if @graduation_album.photos %>
+    <div class="swiper loopSwiper">
+      <div class="swiper-wrapper">
+        <% @graduation_album.photos.each do |photo| %> 
+          <%= image_tag photo.url(:ablum_photo), class:"swiper-slide rounded-lg", id:"loop-swiper" %>
+        <% end %>
       </div>
-    <% end %>
     </div>
+  <% end %>
+</div>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
     <%= render 'events/events', { graduation_album: @graduation_album, events: @events } %>
-    <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks } %>
+    <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks, rank_choices: @rank_choices } %>
     <%= render 'suprise_messages/suprise_messages', { graduation_album: @graduation_album, suprise_messages: @suprise_messages } %>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= stylesheet_pack_tag 'application' %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_pack_tag 'application' %>
+    <%= javascript_include_tag 'application' %>
   </head>
 
   <body class="flex flex-col min-h-screen">

--- a/app/views/message_for_everyones/_message_for_everyone.html.erb
+++ b/app/views/message_for_everyones/_message_for_everyone.html.erb
@@ -1,20 +1,28 @@
-<!-- person - start -->
-<div class="flex flex-col items-center">
-  <% if current_user.own?(message_for_everyone) %>
-    <%= link_to edit_graduation_album_message_for_everyone_path(message_for_everyone.graduation_album, message_for_everyone), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do %>
-      <i class="fa-solid fa-pen-to-square fa-lg"></i>
-    <% end %>
-    <%= link_to graduation_album_message_for_everyone_path(message_for_everyone.graduation_album, message_for_everyone), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do%>
-      <i class="fa-solid fa-trash-can fa-lg"></i>
-    <% end %>
-  <% end %>
-  <div>
-    <p class="text-gray-500 text-sm md:text-base text-center mb-3 md:mb-4"></p>
-    <%= message_for_everyone.body %>
+
+    <!-- article - start -->
+  <div class="card w-96 bg-base-100 shadow-xl">
+    <div class="card-body">
+      <h2 class="card-title">
+      <div class="avatar">
+        <div class="w-12 rounded-full ">
+          <%= link_to graduation_album_menber_path(message_for_everyone.graduation_album, message_for_everyone.user) do %>
+            <%= image_tag current_user.avatar.to_s %>
+          <% end %>
+        </div>
+      </div>
+      <%= link_to message_for_everyone.user.name, graduation_album_menber_path(message_for_everyone.graduation_album, message_for_everyone.user), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+      </h2>
+        <%= message_for_everyone.body %>
+      <div class="card-actions justify-end">
+        <% if current_user.own?(message_for_everyone) %>
+          <%= link_to edit_graduation_album_message_for_everyone_path(message_for_everyone.graduation_album, message_for_everyone), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do %>
+            <i class="fa-solid fa-pen-to-square fa-lg"></i>
+          <% end %>
+          <%= link_to graduation_album_message_for_everyone_path(message_for_everyone.graduation_album, message_for_everyone), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do%>
+            <i class="fa-solid fa-trash-can fa-lg"></i>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
   </div>
-  <div class="w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">
-      <%= image_tag current_user.avatar.to_s %>
-  </div>
-  <%= link_to message_for_everyone.user.name, graduation_album_menber_path(message_for_everyone.graduation_album, message_for_everyone.user), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-</div>
-<!-- person - end -->
+

--- a/app/views/message_for_everyones/_message_for_everyones.html.erb
+++ b/app/views/message_for_everyones/_message_for_everyones.html.erb
@@ -1,3 +1,5 @@
-<div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 lg:gap-x-8 gap-y-8 lg:gap-y-12">
-  <%= render message_for_everyones %>
+<div class="max-w-screen-2xl px-2 md:px-4 mx-auto">
+  <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6">
+    <%= render message_for_everyones %>
+  </div>
 </div>

--- a/app/views/ranks/_rank.html.erb
+++ b/app/views/ranks/_rank.html.erb
@@ -1,26 +1,53 @@
 <div class="card lg:card-side bg-base-100 my-6 shadow-xl">
   <div class="card-body ">
-    <h2 class="card-title"><%= link_to rank.rank_title, graduation_album_rank_path(rank.graduation_album, rank)%></h2>
-    <% rank.rank_choices.order(answers_count: 'DESC').each do |choice| %>
-        <div class="flex items-center mt-4">
-          <div class="grid grid-cols-6 gap-4">
-            <span class="col-span-2 text-sm font-medium text-blue-600 dark:text-blue-500"><%= choice.content %></span>
-            <div class="self-center col-span-3 h-5 mx-4 bg-gray-200 rounded dark:bg-gray-700">
-              <% unless choice.answers.count == 0 %>
-                <div class="col-span-3  h-5 bg-yellow-400 rounded" style="width:<%= (choice.answers.count.quo(rank.answers.count).to_f*100).floor %>%"></div>
-              <% else %>
-                <div class="col-span-3 h-5 bg-yellow-400 rounded" style="width:0%"></div>
+    <div class= 'col-span-1'>
+    <div class="grid grid-cols-12 gap-4">
+      <div class="col-start-2 col-span-8 text-gray-700 text-center px-4 py-2 m-2 text-2xl font-bold">
+        <%= link_to rank.rank_title, graduation_album_rank_path(rank.graduation_album, rank)%>
+      </div>
+      <div class="col-end-13 col-span-2 text-gray-700 text-center px-4 py-2 m-2">
+        <div class="flex flex-row">
+          <% if current_user.own?(rank) %>
+            <div class="m-2">
+              <%= link_to edit_graduation_album_rank_path(rank.graduation_album, rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do %>
+                <i class="fa-solid fa-pen-to-square fa-lg"></i>
               <% end %>
             </div>
-          <span class="self-center col-span-1 text-sm font-medium text-blue-600 dark:text-blue-500"><%= choice.answers.count %></span>
-          </div>
+            <div class="m-2">
+              <%= link_to graduation_album_rank_path(rank.graduation_album, rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do%>
+                <i class="fa-solid fa-trash-can fa-lg"></i>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </div>
-      <p> </p>
+    </div>
+    <% rank.rank_choices.order(answers_count: 'DESC').each do |choice| %>
+      <div class="flex items-center mt-4">
+        <div class="grid grid-cols-12 flex items-center mt-4">
+          <span class="col-span-2 text-sm font-medium text-blue-600 dark:text-blue-500"><%= choice.content %></span>
+          <div class="self-center col-span-7 h-5 mx-4 bg-gray-200 rounded dark:bg-gray-700">
+            <% unless choice.answers.count == 0 %>
+              <div class="col-span-7 h-5 bg-yellow-400 rounded" style="width:<%= (choice.answers.count.quo(rank.answers.count).to_f*100).floor %>%"></div>
+            <% else %>
+              <div class="col-span-7 h-5 bg-yellow-400 rounded" style="width:0%"></div>
+            <% end %>
+          </div>
+          <span class="self-center col-span-1 text-sm font-medium text-blue-600 dark:text-blue-500 text-center"><%= choice.answers.count %>票</span>
+          <span class="self-center col-span-1 text-sm font-medium text-blue-600 dark:text-blue-500 text-center">
+          <%= link_to answers_path(rank_id: rank.id, id: choice.id), method: :post do %>
+            <i class="fa-solid fa-check-to-slot fa-lg"></i>
+          <% end %>
+        </div>
+      </div>
     <% end %>
-      <% if current_user.own?(rank) %>
-        <%= link_to '編集', edit_graduation_album_rank_path(rank.graduation_album, rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
-        <%= link_to '削除', graduation_album_rank_path(rank.graduation_album, rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-      <% end %>
+    <div class='grid grid-cols-12 gap-4 pt-4'>
+      <div class="col-start-12 col-end-13 font-bold">
+        <%= link_to graduation_album_rank_path(rank.graduation_album, rank) do %>
+          <i class="fa-solid fa-arrow-up-right-from-square fa-lg"></i>
+        <% end %>
+      </div>
+    </div>
     </div>
   </div>
 </div>

--- a/app/views/ranks/_rank.html.erb
+++ b/app/views/ranks/_rank.html.erb
@@ -1,9 +1,22 @@
 <div class="card lg:card-side bg-base-100 my-6 shadow-xl">
-  <figure><img src="https://api.lorem.space/image/album?w=400&h=400" alt="Album"></figure>
-  <div class="card-body">
+  <div class="card-body ">
     <h2 class="card-title"><%= link_to rank.rank_title, graduation_album_rank_path(rank.graduation_album, rank)%></h2>
-    <p> <%= rank.rank_description %></p>
-    <div class="card-actions justify-end">
+    <% rank.rank_choices.order(answers_count: 'DESC').each do |choice| %>
+        <div class="flex items-center mt-4">
+          <div class="grid grid-cols-6 gap-4">
+            <span class="col-span-2 text-sm font-medium text-blue-600 dark:text-blue-500"><%= choice.content %></span>
+            <div class="self-center col-span-3 h-5 mx-4 bg-gray-200 rounded dark:bg-gray-700">
+              <% unless choice.answers.count == 0 %>
+                <div class="col-span-3  h-5 bg-yellow-400 rounded" style="width:<%= (choice.answers.count.quo(rank.answers.count).to_f*100).floor %>%"></div>
+              <% else %>
+                <div class="col-span-3 h-5 bg-yellow-400 rounded" style="width:0%"></div>
+              <% end %>
+            </div>
+          <span class="self-center col-span-1 text-sm font-medium text-blue-600 dark:text-blue-500"><%= choice.answers.count %></span>
+          </div>
+      </div>
+      <p> </p>
+    <% end %>
       <% if current_user.own?(rank) %>
         <%= link_to '編集', edit_graduation_album_rank_path(rank.graduation_album, rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
         <%= link_to '削除', graduation_album_rank_path(rank.graduation_album, rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>

--- a/app/views/ranks/_ranks.html.erb
+++ b/app/views/ranks/_ranks.html.erb
@@ -2,10 +2,8 @@
   <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">メンバーランキング</h2>
   <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">〇〇になりそうな人ランキングを作成しよう</p>
 </div>
-<div class="max-w-screen-2xl px-2 md:px-4 mx-auto">
-  <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6">
-    <%= render @ranks %>
-  </div>
+<div class="grid grid-cols-2 gap-4">
+  <%= render @ranks %>
 </div>
 <div class='text-center'>
   <button class="btn btn-outline"><%= link_to 'ランキングを作成', new_graduation_album_rank_path(graduation_album) %></button>

--- a/app/views/ranks/_ranks.html.erb
+++ b/app/views/ranks/_ranks.html.erb
@@ -2,5 +2,11 @@
   <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">メンバーランキング</h2>
   <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">〇〇になりそうな人ランキングを作成しよう</p>
 </div>
-<%= render ranks %>
-<button class="btn btn-outline"><%= link_to 'ランキングを作成', new_graduation_album_rank_path(graduation_album) %></button>
+<div class="max-w-screen-2xl px-2 md:px-4 mx-auto">
+  <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6">
+    <%= render @ranks %>
+  </div>
+</div>
+<div class='text-center'>
+  <button class="btn btn-outline"><%= link_to 'ランキングを作成', new_graduation_album_rank_path(graduation_album) %></button>
+</div>

--- a/app/views/ranks/show.html.erb
+++ b/app/views/ranks/show.html.erb
@@ -1,16 +1,37 @@
-<% if current_user.own?(@rank) %>
-  <%= link_to '編集', edit_graduation_album_rank_path(@rank.graduation_album, @rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
-  <%= link_to '削除', graduation_album_rank_path(@rank.graduation_album, @rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-<% end %>
-<br>
-<%= @rank.rank_title %><br>
-<%= @rank.rank_description %>
-<br>
-<% unless @rank_choices == nil%>
-  <% @rank_choices.each do |choice| %>
-    <%= link_to '編集', edit_graduation_album_rank_rank_choice_path(@rank.graduation_album, @rank, choice), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %> 
-    <%= link_to '削除', graduation_album_rank_rank_choice_path(@rank.graduation_album, @rank, choice), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-    <%= link_to choice.content, answers_path(rank_id: @rank.id, id: choice.id), method: :post %> <%= choice.answers.count %>票
-  <% end %>
-<% end %>
-<button class="btn btn-outline"><%= link_to '選択肢を追加', new_graduation_album_rank_rank_choice_path(@rank.graduation_album, @rank) %></button>
+<div class="hero min-h-screen bg-base-200">
+  <div class="hero-content text-center self-start pt-8">
+    <div class="card lg:card-side bg-base-100 my-6 shadow-xl">
+      <div class="card-body ">
+        <% if current_user.own?(@rank) %>
+            <%= link_to '編集', edit_graduation_album_rank_path(@rank.graduation_album, @rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
+            <%= link_to '削除', graduation_album_rank_path(@rank.graduation_album, @rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
+          <% end %>
+        <h2 class="card-title"><%= @rank.rank_title %></h2>
+        <%= @rank.rank_description %>
+        <% @rank.rank_choices.order(answers_count: "DESC").each do |choice| %>
+          <div class="grid grid-cols-12 flex items-center mt-4">
+            <div class="text-2xl col-span-3 text-sm font-medium text-blue-600 dark:text-blue-500 text-center">
+              <i class="fa-solid fa-crown"></i> <%= choice.content %>
+            </div>
+            <div class="self-center col-span-7 h-5 mx-4 bg-gray-200 rounded dark:bg-gray-700">
+              <% unless choice.answers.count == 0 %>
+                <div class="col-span-7 h-5 bg-yellow-400 rounded" style="width:<%= (choice.answers.count.quo(@rank.answers.count).to_f*100).floor %>%"></div>
+              <% else %>
+                <div class="col-span-7 h-5 bg-yellow-400 rounded" style="width:0%"></div>
+              <% end %>
+            </div>
+            <span class="self-center col-span-1 text-sm font-medium text-blue-600 dark:text-blue-500 text-center text-2xl"><%= choice.answers.count %>票</span>
+            <span class="self-center col-span-1 text-sm font-medium text-blue-600 dark:text-blue-500 text-center">
+              <%= link_to answers_path(rank_id: @rank.id, id: choice.id), method: :post do %>
+                <i class="fa-solid fa-check-to-slot fa-2x"></i>
+              <% end %>
+            </span>
+          </div>
+        <% end %>
+        <div class='pt-6'>
+          <button class="btn btn-outline"><%= link_to '選択肢を追加', new_graduation_album_rank_rank_choice_path(@rank.graduation_album, @rank) %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/ranks/show.html.erb
+++ b/app/views/ranks/show.html.erb
@@ -1,13 +1,23 @@
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content text-center self-start pt-8">
     <div class="card lg:card-side bg-base-100 my-6 shadow-xl">
-      <div class="card-body ">
-        <% if current_user.own?(@rank) %>
-            <%= link_to '編集', edit_graduation_album_rank_path(@rank.graduation_album, @rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" %>
-            <%= link_to '削除', graduation_album_rank_path(@rank.graduation_album, @rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-          <% end %>
-        <h2 class="card-title"><%= @rank.rank_title %></h2>
-        <%= @rank.rank_description %>
+      <div class="card-body">
+        <div class='p-2'>
+          <div class="grid grid-cols-5 gap-4">
+            <div class="col-start-2 col-span-3 text-gray-700 text-center px-4 py-2 m-2 text-2xl font-bold"><%= @rank.rank_title %></div>
+            <div class="col-end-6 col-span-1 text-gray-700 text-center px-4 py-2 m-2">
+              <% if current_user.own?(@rank) %>
+                <%= link_to edit_graduation_album_rank_path(@rank.graduation_album, @rank), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do %>
+                  <i class="fa-solid fa-pen-to-square fa-lg"></i>
+                <% end %>
+                <%= link_to graduation_album_rank_path(@rank.graduation_album, @rank), method: :delete, id: "delete_button", data: {confirm: "本当に削除しますか？"},  class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100" do%>
+                  <i class="fa-solid fa-trash-can fa-lg"></i>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+          <%= @rank.rank_description %>
+        </div>
         <% @rank.rank_choices.order(answers_count: "DESC").each do |choice| %>
           <div class="grid grid-cols-12 flex items-center mt-4">
             <div class="text-2xl col-span-3 text-sm font-medium text-blue-600 dark:text-blue-500 text-center">

--- a/app/views/suprise_messages/_suprise_messages.html.erb
+++ b/app/views/suprise_messages/_suprise_messages.html.erb
@@ -3,4 +3,6 @@
   <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">未来に向けてメッセージを残そう</p>
 </div>
 <%= render suprise_messages %>
-<button class="btn btn-outline"><%= link_to 'サプライズメッセージを作成', new_graduation_album_suprise_message_path(@graduation_album) %></button>
+<div class='text-center'>
+  <button class="btn btn-outline"><%= link_to 'サプライズメッセージを作成', new_graduation_album_suprise_message_path(@graduation_album) %></button>
+</div>

--- a/db/migrate/20220713081736_add_answers_count_to_rank_choices.rb
+++ b/db/migrate/20220713081736_add_answers_count_to_rank_choices.rb
@@ -1,0 +1,5 @@
+class AddAnswersCountToRankChoices < ActiveRecord::Migration[6.1]
+  def change
+    add_column :rank_choices, :answers_count, :integer
+  end
+end

--- a/db/migrate/20220713130702_change_column_default_to_rank_choices.rb
+++ b/db/migrate/20220713130702_change_column_default_to_rank_choices.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultToRankChoices < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :rank_choices, :answers_count, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_080954) do
+ActiveRecord::Schema.define(version: 2022_07_13_081736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_080954) do
     t.bigint "rank_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "answers_count"
     t.index ["rank_id"], name: "index_rank_choices_on_rank_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_13_081736) do
+ActiveRecord::Schema.define(version: 2022_07_13_130702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,7 +98,7 @@ ActiveRecord::Schema.define(version: 2022_07_13_081736) do
     t.bigint "rank_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "answers_count"
+    t.integer "answers_count", default: 0
     t.index ["rank_id"], name: "index_rank_choices_on_rank_id"
   end
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "daisyui": "^2.15.4",
     "postcss": "8",
     "postcss-loader": "4",
+    "swiper": "^8.3.0",
     "tailwindcss": "2",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"

--- a/spec/models/rank_choice_spec.rb
+++ b/spec/models/rank_choice_spec.rb
@@ -3,7 +3,7 @@
 # Table name: rank_choices
 #
 #  id            :bigint           not null, primary key
-#  answers_count :integer
+#  answers_count :integer          default(0)
 #  content       :string           not null
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/spec/models/rank_choice_spec.rb
+++ b/spec/models/rank_choice_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: rank_choices
 #
-#  id         :bigint           not null, primary key
-#  content    :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  rank_id    :bigint           not null
+#  id            :bigint           not null, primary key
+#  answers_count :integer
+#  content       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  rank_id       :bigint           not null
 #
 # Indexes
 #

--- a/yarn.lock
+++ b/yarn.lock
@@ -2738,6 +2738,13 @@ dom-serializer@0:
     domelementtype "^2.0.1"
     entities "^2.0.0"
 
+dom7@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/dom7/-/dom7-4.0.4.tgz#8b68c5d8e5e2ed0fddb1cb93e433bc9060c8f3fb"
+  integrity sha512-DSSgBzQ4rJWQp1u6o+3FVwMNnT5bzQbMb+o31TjYYeRi05uAcpF8koxdfzeoe5ElzPmua7W7N28YJhF7iEKqIw==
+  dependencies:
+    ssr-window "^4.0.0"
+
 domain-browser@^1.1.1:
   version "1.2.0"
   resolved "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz"
@@ -6655,6 +6662,11 @@ sprintf-js@~1.0.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
 
+ssr-window@^4.0.0, ssr-window@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/ssr-window/-/ssr-window-4.0.2.tgz#dc6b3ee37be86ac0e3ddc60030f7b3bc9b8553be"
+  integrity sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==
+
 ssri@^6.0.1:
   version "6.0.2"
   resolved "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz"
@@ -6850,6 +6862,14 @@ svgo@^1.0.0:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+swiper@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/swiper/-/swiper-8.3.0.tgz#3ed7498d978c03fdcebc77e1780c5f17829c6857"
+  integrity sha512-pdrENUco8MVyJ/cTZMQ5c9AqZDRYGJChd+5lcDsoGpKhgOloSzS7hMvgH+ipvTVCaNOCTlSaf5ZYm1Jz5TqKDQ==
+  dependencies:
+    dom7 "^4.0.4"
+    ssr-window "^4.0.2"
 
 tailwindcss@2:
   version "2.2.19"


### PR DESCRIPTION
## 関連するissue
close #63 

## 概要
以下を実行しました。

・swiperを導入してアルバム詳細画面の写真をスライド形式に変更
・ランキング機能のデザインを変更
・イベント機能のデザインを変更
・herokuへのデプロイ

## 確認事項
特になし

## 懸念点
特になし。

## 参考記事
特になし。