### PR TITLE
Fix: 写真に人物が写っていない場合は顔写真の情報を保存しないように設定#75

### DIFF
--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -49,8 +49,10 @@ class GraduationAlbumsController < ApplicationController
               }
             }
           })
-          image_detail = PhotoPath.new(graduation_album_id: @graduation_album.id, path: image.blob_id.to_s, image_id: resp.to_h[:face_records][0][:face][:image_id])
-          image_detail.save!
+          unless resp.to_h[:face_records] == []
+            image_detail = PhotoPath.new(graduation_album_id: @graduation_album.id, path: image.blob_id.to_s, image_id: resp.to_h[:face_records][0][:face][:image_id])
+            image_detail.save!
+          end
         end
       end
       redirect_to graduation_albums_path, notice: '作成に成功しました'


### PR DESCRIPTION
## 関連するissue
close #75 

## 概要
以下を実行しました。

・投稿された画像に人物が写っていない場合は顔情報保存の処理を実行しない

## 確認事項
特になし

## 確認方法
人物の顔が写っていない写真を投稿してもエラーが発生しないことで確認できます。

## 懸念点
特になし。

## 参考記事
特になし。