### PR TITLE
feat: パンクズリスト作成のため、gemの追加とviewを編集#73

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,3 +94,5 @@ gem 'aws-sdk-rekognition'
 gem 'mini_magick'
 # 非同期処理のため
 gem 'jquery-rails'
+#パンクズリスト
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,9 @@ GEM
     formatador (1.1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    gretel (4.4.0)
+      actionview (>= 5.1, < 7.1)
+      railties (>= 5.1, < 7.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -425,6 +428,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   fog-aws
+  gretel
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :event_show, @event.graduation_album, @event %>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <!-- text - start -->

--- a/app/views/graduation_albums/edit.html.erb
+++ b/app/views/graduation_albums/edit.html.erb
@@ -1,1 +1,2 @@
+<% breadcrumb :graduation_album_edit, @graduation_album %>
 <%= render 'form', { graduation_album: @graduation_album } %>

--- a/app/views/graduation_albums/index.html.erb
+++ b/app/views/graduation_albums/index.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :root %>
 <div class="bg-white py-3 sm:py-4 lg:py-6">
   <div class="max-w-screen-2xl px-2 md:px-4 mx-auto">
     <!-- text - start -->

--- a/app/views/graduation_albums/new.html.erb
+++ b/app/views/graduation_albums/new.html.erb
@@ -1,1 +1,2 @@
+<% breadcrumb :graduation_album_new %>
 <%= render 'form', { graduation_album: @graduation_album } %>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :graduation_album, @graduation_album %>
 <div class="bg-white py-3 sm:py-4 lg:py-6">
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <!-- text - start -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <% end %>
     <%= render 'shared/flash' %>
     <div class='flex-grow'>
+    <%= breadcrumbs separator: " &rsaquo; " %> 
       <%= yield %>
     </div>
     <%= render 'shared/footer' %>

--- a/app/views/menbers/show.html.erb
+++ b/app/views/menbers/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :menber_show, @graduation_album, @menber %>
 <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 underline">メンバー</h2>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-xl px-4 md:px-8 mx-auto">

--- a/app/views/ranks/show.html.erb
+++ b/app/views/ranks/show.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :rank_show, @rank.graduation_album, @rank %>
 <div class="hero min-h-screen bg-base-200">
   <div class="hero-content text-center self-start pt-8">
     <div class="card lg:card-side bg-base-100 my-6 shadow-xl">

--- a/app/views/suprise_messages/show.html.erb
+++ b/app/views/suprise_messages/show.html.erb
@@ -1,2 +1,3 @@
+<% breadcrumb :suprise_show, @suprise_message.graduation_album, @suprise_message %>
 <h1>SupriseMessages#show</h1>
 <p>Find me in app/views/suprise_messages/show.html.erb</p>

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,38 @@
+crumb :root do
+  link "Home", graduation_albums_path
+end
+
+crumb :graduation_album_new do
+  link "アルバム作成", new_graduation_album_path
+  parent :root
+end
+
+crumb :graduation_album_edit do |graduation_album|
+  link "アルバム編集", edit_graduation_album_path(graduation_album)
+  parent :root
+end
+
+crumb :graduation_album do |graduation_album|
+  link "#{graduation_album.album_name}", graduation_album_path(graduation_album)
+  parent :root
+end
+
+crumb :menber_show do |graduation_album, menber|
+  link "#{menber.name}さんの詳細"
+  parent :graduation_album, graduation_album
+end
+
+crumb :event_show do |graduation_album, event|
+  link "#{event.title}"
+  parent :graduation_album, graduation_album
+end
+
+crumb :rank_show do |graduation_album, rank|
+  link "#{rank.rank_title}"
+  parent :graduation_album, graduation_album
+end
+
+crumb :suprise_show do |graduation_album, suprise_message|
+  link "#{suprise_message.suprise_title}"
+  parent :graduation_album, graduation_album
+end


### PR DESCRIPTION
## 関連するissue
close #73 

## 概要
以下を実行しました。

・パンクズリスト作成のためにgem 'gretel'をインストール
・アルバム詳細、イベント詳細、ランキング詳細、メンバー詳細、サプライズメッセージ詳細にそれぞれリストを追加

## 確認事項
特になし

## 確認方法
該当ページにアクセスしてページ右上にリストが表示されることを確認できます。

## 懸念点
特になし。

## 参考記事
特になし。