### PR TITLE
Add validation for message

### DIFF
--- a/app/models/message_for_each_menber.rb
+++ b/app/models/message_for_each_menber.rb
@@ -27,4 +27,5 @@ class MessageForEachMenber < ApplicationRecord
   belongs_to :graduation_album
 
   validates :body, presence: true, length: { maximum: 65_535 }
+  validates_uniqueness_of :graduation_album_id,  message: "メッセージは1人1つまでです", scope: :user_id
 end

--- a/app/models/message_for_everyone.rb
+++ b/app/models/message_for_everyone.rb
@@ -26,4 +26,5 @@ class MessageForEveryone < ApplicationRecord
   belongs_to :graduation_album
 
   validates :body, presence: true, length: { maximum: 65_535 }
+  validates_uniqueness_of :graduation_album_id,  message: "メッセージは1人1つまでです", scope: :user_id
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Album
     config.load_defaults 6.1
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.active_model.i18n_customize_full_message = true
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -30,3 +30,13 @@ ja:
         suprise_title: 'タイトル'
         suprise_message: 'メッセージ'
         suprise_time: 'サプライズ実行日'
+    errors:
+      models:
+        message_for_each_menber:
+          attributes:
+            graduation_album_id:
+              format: '%{message}'
+        message_for_everyone:
+          attributes:
+            graduation_album_id:
+              format: '%{message}'


### PR DESCRIPTION
## 関連するissue
close #69 

## 概要
以下を実行しました。

・エラーメッセージの先頭に属性名が入らないように設定を編集
・全体メッセージは1つのアルバムで1人一回までに制限
・個別メッセージは1つのアルバムで1人一回までに制限

## 確認事項
特になし

## 確認方法
同じアルバム内で2回メッセージを送ることで確認できます。

## 懸念点
特になし。

## 参考記事
[参考記事](https://qiita.com/okeicalm/items/9638250ddfb361d80a16)