### PR TITLE
Add: メンバー詳細ページにユーザーに関連するイベント、ランク、サプライズを追加#67

### DIFF
--- a/app/controllers/menbers_controller.rb
+++ b/app/controllers/menbers_controller.rb
@@ -33,5 +33,8 @@ class MenbersController < ApplicationController
     end
     @message_for_each_menbers = @graduation_album.message_for_each_menbers.where(to_user: @menber.id).includes(:user).order(created_at: :desc)
     @message_for_each_menber = MessageForEachMenber.new
+    @ranks = @menber.ranks.includes([:graduation_album])
+    @suprise_messages = @menber.suprise_messages.includes([:graduation_album])
+    @events = @menber.events.includes([:graduation_album])
   end
 end

--- a/app/views/events/_events.html.erb
+++ b/app/views/events/_events.html.erb
@@ -1,7 +1,4 @@
-<div class="mb-10 md:mb-16">
-  <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">思い出の行事</h2>
-  <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">みんなとの楽しい思い出を共有しよう</p>
-</div>
+
 <ol class="relative border-l border-gray-200 dark:border-gray-700">                  
   <%= render events %>
 </ol>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -62,8 +62,20 @@
 </div>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
+    <div class="mb-10 md:mb-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">思い出の行事</h2>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">みんなとの楽しい思い出を共有しよう</p>
+    </div>
     <%= render 'events/events', { graduation_album: @graduation_album, events: @events } %>
-    <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks, rank_choices: @rank_choices } %>
+    <div class="mb-10 md:mb-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">メンバーランキング</h2>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">〇〇になりそうな人ランキングを作成しよう</p>
+    </div>
+    <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks} %>
+    <div class="mb-10 md:mb-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">サプライズメッセージ</h2>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">未来に向けてメッセージを残そう</p>
+    </div>
     <%= render 'suprise_messages/suprise_messages', { graduation_album: @graduation_album, suprise_messages: @suprise_messages } %>
   </div>
 </div>

--- a/app/views/menbers/show.html.erb
+++ b/app/views/menbers/show.html.erb
@@ -23,5 +23,49 @@
     </div>
     <%= render 'message_for_each_menbers/message_for_each_menbers', { message_for_each_menbers: @message_for_each_menbers } %>
     <%= render 'message_for_each_menbers/form', { graduation_album: @graduation_album, message_for_each_menber: @message_for_each_menber, menber: @menber } %>
+    <% unless @menber.ranks == [] %>
+      <div class="mb-10 md:mb-16">
+        <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-6 md:mb-3"><%= "#{@menber.name}"%>さんが作成したランキング</h2>
+      </div>
+      <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks } %>
+    <% else %>
+      <div class="mb-10 md:mb-16">
+        <h3 class="text-gray-800 text-2xl font-bold text-center mb-6 mt-6 md:mb-3"><%= "#{@menber.name}"%>さんが作成したランキングはまだありません</h3>
+      <div class='text-center'>
+        <p>ランキングを作成してアルバムを盛り上げよう</p>
+          <button class="btn btn-outline"><%= link_to 'イベントを作成', new_graduation_album_rank_path(@graduation_album) %></button>
+        </div>
+      </div>
+    <% end %>
+
+    <% unless @menber.events == [] %>
+      <div class="mb-10 md:mb-16">
+        <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6"><%= "#{@menber.name}"%>さんが作成したイベント</h2>
+      </div>
+      <%= render 'events/events', { graduation_album: @graduation_album, events: @events } %>
+    <% else %>
+      <div class="mb-10 md:mb-16">
+        <h3 class="text-gray-800 text-2xl font-bold text-center mb-6 mt-6 md:mb-3"><%= "#{@menber.name}"%>さんが作成したイベントはまだありません</h3>
+      <div class='text-center'>
+        <p>イベントを作成してアルバムを盛り上げよう</p>
+          <button class="btn btn-outline"><%= link_to 'イベントを作成', new_graduation_album_event_path(@graduation_album) %></button>
+        </div>
+      </div>
+    <% end %>
+
+    <% unless @menber.suprise_messages == [] %>
+      <div class="mb-10 md:mb-16">
+        <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6"><%= "#{@menber.name}"%>さんが作成したサプライズメッセージ</h2>
+      </div>
+      <%= render 'suprise_messages/suprise_messages', { graduation_album: @graduation_album, suprise_messages: @suprise_messages } %>
+    <% else %>
+      <div class="mb-10 md:mb-16">
+        <h3 class="text-gray-800 text-2xl font-bold text-center mb-6 mt-6 md:mb-3"><%= "#{@menber.name}"%>さんが作成したサプライズメッセージはまだありません</h3>
+      <div class='text-center'>
+        <p>サプライズメッセージを作成してアルバムを盛り上げよう</p>
+          <button class="btn btn-outline"><%= link_to 'イベントを作成', new_graduation_album_event_path(@graduation_album) %></button>
+        </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/ranks/_ranks.html.erb
+++ b/app/views/ranks/_ranks.html.erb
@@ -1,7 +1,3 @@
-<div class="mb-10 md:mb-16">
-  <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">メンバーランキング</h2>
-  <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">〇〇になりそうな人ランキングを作成しよう</p>
-</div>
 <div class="grid grid-cols-2 gap-4">
   <%= render @ranks %>
 </div>

--- a/app/views/suprise_messages/_suprise_messages.html.erb
+++ b/app/views/suprise_messages/_suprise_messages.html.erb
@@ -1,7 +1,3 @@
-<div class="mb-10 md:mb-16">
-  <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">サプライズメッセージ</h2>
-  <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">未来に向けてメッセージを残そう</p>
-</div>
 <%= render suprise_messages %>
 <div class='text-center'>
   <button class="btn btn-outline"><%= link_to 'サプライズメッセージを作成', new_graduation_album_suprise_message_path(@graduation_album) %></button>


### PR DESCRIPTION
## 関連するissue
close #67

## 概要
以下を実行しました。

・メンバー詳細画面にメンバーの投稿したイベント、ランキング、サプライズメッセージが投稿される

## 確認事項
特になし

## 確認方法
メンバー詳細画面にアクセスすることで確認できます。

## 懸念点
特になし。

## 参考記事
特になし。