### PR TITLE
ユーザー詳細画面にフォロー・フォロワー一覧を表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,3 +96,5 @@ gem 'mini_magick'
 gem 'jquery-rails'
 #パンクズリスト
 gem 'gretel'
+#ユーザー検索
+gem 'ransack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,10 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (3.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -442,6 +446,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.6)
   rails-i18n
+  ransack
   rspec-rails
   rubocop
   rubocop-rails

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -2,22 +2,14 @@ class RelationshipsController < ApplicationController
   def create
     @user = User.find(params[:follow_id])
     following = current_user.follow(@user)
-    if following.save
-      flash[:success] = 'ユーザーをフォローしました'
-    else
-      flash.now[:alert] = 'ユーザーのフォローに失敗しました'
-    end
-    redirect_to graduation_albums_path
+    following.save!
+    redirect_to users_show_path
   end
 
   def destroy
     @user = User.find(params[:follow_id])
     following = current_user.unfollow(@user)
-    if following.destroy
-      flash[:success] = 'ユーザーのフォローを解除しました'
-    else
-      flash.now[:alert] = 'ユーザーのフォロー解除に失敗しました'
-    end
-    redirect_to graduation_albums_path
+    following.destroy!
+    redirect_to users_show_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,7 @@
 class UsersController < ApplicationController
   def show
     @user = current_user
+    @following_users = @user.followings
+    @followed_users = @user.followers
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,5 +3,7 @@ class UsersController < ApplicationController
     @user = current_user
     @following_users = @user.followings
     @followed_users = @user.followers
+    @q = User.ransack(params[:q])
+    @users = @q.result(distinct: true)
   end
 end

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -12,8 +12,12 @@
     <div class="mb-8">
       <% unless current_user.followings.count == 0 %>
         <%= f.label :user_ids, 'メンバー', class: "text-sm block"%>
-        <%= f.collection_check_boxes :user_ids, User.all, :id, :name %>
-        <%= link_to "招待したいユーザーをフォローしよう", users_show_path %>
+        <%= f.collection_check_boxes :user_ids, current_user.followings, :id, :name %>
+        <div class='text-center pt-6'>
+          <button class="btn btn-outline btn-accent">
+            <%= link_to "招待したいユーザーをフォローしよう", users_show_path %>
+          </button>
+        </div>
       <% else %>
         <%= f.label :user_ids, 'フォローしているユーザーがいません', class: "text-sm block"%>
         <div class='text-center pt-6'>

--- a/app/views/graduation_albums/_form.html.erb
+++ b/app/views/graduation_albums/_form.html.erb
@@ -12,9 +12,15 @@
     <div class="mb-8">
       <% unless current_user.followings.count == 0 %>
         <%= f.label :user_ids, 'メンバー', class: "text-sm block"%>
-        <%= f.collection_check_boxes :user_ids, current_user.followings, :id, :name %>
+        <%= f.collection_check_boxes :user_ids, User.all, :id, :name %>
+        <%= link_to "招待したいユーザーをフォローしよう", users_show_path %>
       <% else %>
-        フォロワーがいません
+        <%= f.label :user_ids, 'フォローしているユーザーがいません', class: "text-sm block"%>
+        <div class='text-center pt-6'>
+          <button class="btn btn-outline btn-accent">
+            <%= link_to "招待したいユーザーをフォローしよう", users_show_path %>
+          </button>
+        </div>
       <% end %>
     </div>
     <div class='form-control mt-6'>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -31,17 +31,23 @@
   <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
     <!-- text - start -->
     <div class="mb-10 md:mb-16">
-      <% @graduation_album.users.each do |user| %>
-        <div class="flex flex-col items-center">
-          <%= link_to graduation_album_menber_path(@graduation_album, user), class:"w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4" do %>
-            <%= image_tag user.avatar.to_s %>
-          <% end %>
-          <%= link_to user.name, graduation_album_menber_path(@graduation_album, user), class: "text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
-        </div>
-      <% end %>
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center pt-4 mb-4 md:mb-6 underline">メンバーからのメッセージ</h2>
+      <div class="grid grid-cols-2 md:grid-cols-5 gap-x-2 lg:gap-x-4 gap-y-4 lg:gap-y-4">
+        <!-- person - start -->
+        <% @graduation_album.users.each do |user| %>
+          <div class="flex flex-col items-center">
+            <%= link_to graduation_album_menber_path(@graduation_album, user), class:"w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4" do %>
+              <%= image_tag user.avatar.to_s ,class: "w-full h-full object-cover object-center" %>
+            <% end %>
+            <div class="text-indigo-500 md:text-lg font-bold text-center">
+              <%= link_to user.name, graduation_album_menber_path(@graduation_album, user)%>
+            </div>
+          </div>
+        <% end %>
+        <!-- person - end -->
+      </div>
     </div>
     <!-- text - end -->
+    <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center pt-4 mb-4 md:mb-6 underline pt-10">メンバーからのメッセージ</h2>
     <%if @message_for_everyones %>
       <%= render 'message_for_everyones/message_for_everyones', { message_for_everyones: @message_for_everyones } %>
     <% end %>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -3,7 +3,6 @@
   <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
     <!-- text - start -->
     <div class="mb-10 md:mb-16">
-      <h1 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 underline"><%= @graduation_album.album_name %></h1>
       <div class="bg-white py-3 sm:py-4 lg:py-6">
         <div class=" px-4 md:px-8 mx-auto">
           <% if @graduation_album.images %>

--- a/app/views/menbers/show.html.erb
+++ b/app/views/menbers/show.html.erb
@@ -5,7 +5,7 @@
     <div class="mb-10 md:mb-16">
       <div class='flex justify-center'>
         <div class=" w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">
-          <%= image_tag current_user.avatar.to_s %>
+          <%= image_tag @menber.avatar.to_s %>
         </div>
       </div>
       <p class="text-3xl my-6 text-center dark:text-white">

--- a/app/views/message_for_each_menbers/_message_for_each_menber.html.erb
+++ b/app/views/message_for_each_menbers/_message_for_each_menber.html.erb
@@ -1,6 +1,6 @@
 
 <div id="message_for_each_menber-<%= message_for_each_menber.id %>">
-  <div class="card w-96 bg-base-100 shadow-xl">
+  <div class="card w-80 bg-base-100 shadow-xl">
     <div class="card-body">
       <h2 class="card-title">
       <div class="avatar">

--- a/app/views/message_for_everyones/_message_for_everyone.html.erb
+++ b/app/views/message_for_everyones/_message_for_everyone.html.erb
@@ -1,5 +1,5 @@
 <div id="message_for_everyone-<%= message_for_everyone.id %>">
-  <div class="card w-96 bg-base-100 shadow-xl">
+  <div class="card w-80 bg-base-100 shadow-xl">
     <div class="card-body">
       <h2 class="card-title">
       <div class="avatar">

--- a/app/views/message_for_everyones/_message_for_everyones.html.erb
+++ b/app/views/message_for_everyones/_message_for_everyones.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-screen-2xl px-2 md:px-4 mx-auto">
+<div class="max-w-screen-xl px-4 md:px-8 mx-auto">
   <div id="js-table-message_for_everyone" class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6" >
     <%= render message_for_everyones %>
   </div>

--- a/app/views/ranks/_ranks.html.erb
+++ b/app/views/ranks/_ranks.html.erb
@@ -1,4 +1,4 @@
-<div class="grid grid-cols-2 gap-4">
+<div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-6">
   <%= render @ranks %>
 </div>
 <div class='text-center'>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -39,13 +39,43 @@
       <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">ユーザー検索</h2>
       <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">ユーザーをフォローすることでグループに招待できます</p>
       <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">ユーザーはユーザー名かメールアドレスから検索することができます</p>
-      <input type="text" placeholder="Type here" class="input input-bordered input-accent w-full max-w-xs" />
+      <div class='text-center py-8'>
+        <%= search_form_for @q, url: users_show_path(@user) do |f| %>
+          <%= f.search_field :name_or_email_cont, placeholder:"ユーザー名 or メールアドレス", class:"input input-bordered input-accent w-full max-w-xs" %>
+          <%= button_tag type: 'submit', class: "follow-btn" do %>
+            <i class="fa-solid fa-magnifying-glass fa-lg pl-4"></i>
+          <% end %>
+        <% end %>
+      </div>
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 lg:gap-x-8 gap-y-8 lg:gap-y-12">
+      <% @users.each do |user|%>
+        <div class="flex flex-col items-center">
+          <div class="w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">
+            <%= image_tag user.avatar.to_s ,class: "w-full h-full object-cover object-center" %>
+          </div>
+          <div>
+            <div class="text-indigo-500 md:text-lg font-bold text-center"><%= user.name %></div>
+            <% unless @user == user %>
+              <% if @user.following?(user) %>
+                <%= form_for(@user.relationships.find_by(follow_id: user.id), html: { method: :delete }) do |f| %>
+                  <%= hidden_field_tag :follow_id, user.id %>
+                  <%= f.submit 'Unfollow', class: 'btn btn-danger btn-block' %>
+                <% end %>
+              <% else %>
+                <%= form_for(@user.relationships.build) do |f| %>
+                  <%= hidden_field_tag :follow_id, user.id %>
+                  <%= f.submit 'Follow', class: 'btn btn-primary btn-block' %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     </div>
     <!-- text - end -->
-
     <!-- text - start -->
-    <div class="mb-10 md:mb-16">
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">フォローしているユーザー</h2>
+    <div class="mb-5 md:mb-8">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-2 md:mb-3 pt-10">フォローしているユーザー</h2>
     </div>
     <!-- text - end -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 lg:gap-x-8 gap-y-8 lg:gap-y-12">
@@ -77,8 +107,8 @@
     </div>
 
     <!-- text - start -->
-    <div class="pt-10 md:pt-16">
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">フォローされているユーザー</h2>
+    <div class="pt-5 md:pt-8">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-2 md:mb-3 pt-10">フォローされているユーザー</h2>
     </div>
     <!-- text - end -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 lg:gap-x-8 gap-y-8 lg:gap-y-12">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,20 +11,18 @@
       </div>
         <div class="flex flex-wrap justify-center">
             <div class="w-full flex justify-center">
-                <div class="relative">
-                    <%= image_tag @user.avatar.to_s ,class:"shadow-xl rounded-full align-middle border-none absolute -m-16 -ml-20 lg:-ml-16 max-w-[150px]"%>
+                <div class="w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">
+                  <%= image_tag @user.avatar.to_s ,class: "w-full h-full object-cover object-center" %>
                 </div>
             </div>
-            <div class="w-full text-center mt-20">
-                <div class="flex justify-center lg:pt-4 pt-8 pb-0">
-                    <div class="p-3 text-center">
-                        <span class="text-xl font-bold block uppercase tracking-wide text-slate-700"><%= @user.followers.count %></span>
-                        <span class="text-sm text-slate-400">フォロー</span>
-                    </div>
-                    <div class="p-3 text-center">
-                        <span class="text-xl font-bold block uppercase tracking-wide text-slate-700"><%= @user.followings.count %></span>
-                        <span class="text-sm text-slate-400">フォロワー</span>
-                    </div>
+            <div class="flex justify-center lg:pt-4 pt-8 pb-0">
+                <div class="p-3 text-center">
+                    <span class="text-xl font-bold block uppercase tracking-wide text-slate-700"><%= @user.followers.count %></span>
+                    <span class="text-sm text-slate-400">フォロー</span>
+                </div>
+                <div class="p-3 text-center">
+                    <span class="text-xl font-bold block uppercase tracking-wide text-slate-700"><%= @user.followings.count %></span>
+                    <span class="text-sm text-slate-400">フォロワー</span>
                 </div>
             </div>
         </div>
@@ -33,4 +31,80 @@
           <p class=" text-slate-700 font-bold leading-normal mb-1">メールアドレス：<%= @user.email %></p>
         </div>
     </div>
+</div>
+<div class="bg-white py-3 sm:py-4 lg:py-6">
+  <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
+    <!-- text - start -->
+    <div class="mb-10 md:mb-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">ユーザー検索</h2>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">ユーザーをフォローすることでグループに招待できます</p>
+      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">ユーザーはユーザー名かメールアドレスから検索することができます</p>
+      <input type="text" placeholder="Type here" class="input input-bordered input-accent w-full max-w-xs" />
+    </div>
+    <!-- text - end -->
+
+    <!-- text - start -->
+    <div class="mb-10 md:mb-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">フォローしているユーザー</h2>
+    </div>
+    <!-- text - end -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 lg:gap-x-8 gap-y-8 lg:gap-y-12">
+      <!-- person - start -->
+      <% @following_users.each do |follower|%>
+        <div class="flex flex-col items-center">
+          <div class="w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">
+            <%= image_tag follower.avatar.to_s ,class: "w-full h-full object-cover object-center" %>
+          </div>
+          <div>
+            <div class="text-indigo-500 md:text-lg font-bold text-center"><%= follower.name %></div>
+            <% unless @user == follower %>
+              <% if @user.following?(follower) %>
+                <%= form_for(@user.relationships.find_by(follow_id: follower.id), html: { method: :delete }) do |f| %>
+                  <%= hidden_field_tag :follow_id, follower.id %>
+                  <%= f.submit 'Unfollow', class: 'btn btn-danger btn-block' %>
+                <% end %>
+              <% else %>
+                <%= form_for(@user.relationships.build) do |f| %>
+                  <%= hidden_field_tag :follow_id, follower.id %>
+                  <%= f.submit 'Follow', class: 'btn btn-primary btn-block' %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+      <!-- person - end -->
+    </div>
+
+    <!-- text - start -->
+    <div class="pt-10 md:pt-16">
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6">フォローされているユーザー</h2>
+    </div>
+    <!-- text - end -->
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-x-4 lg:gap-x-8 gap-y-8 lg:gap-y-12">
+      <!-- person - start -->
+      <% @followed_users.each do |followed|%>
+        <div class="flex flex-col items-center">
+          <div class="w-24 md:w-32 h-24 md:h-32 bg-gray-100 rounded-full overflow-hidden shadow-lg mb-2 md:mb-4">
+            <%= image_tag followed.avatar.to_s ,class: "w-full h-full object-cover object-center" %>
+          </div>
+          <div>
+            <div class="text-indigo-500 md:text-lg font-bold text-center"><%= followed.name %></div>
+            <% unless @user == followed %>
+              <% if @user.following?(followed) %>
+                <%= form_for(@user.relationships.find_by(follow_id: followed.id), html: { method: :delete }) do |f| %>
+                  <%= hidden_field_tag :follow_id, followed.id %>
+                  <%= f.submit 'Unfollow', class: 'btn btn-danger btn-block' %>
+                <% end %>
+              <% else %>
+                <%= form_for(@user.relationships.build) do |f| %>
+                  <%= hidden_field_tag :follow_id, followed.id %>
+                  <%= f.submit 'Follow', class: 'btn btn-primary btn-block' %>
+                <% end %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+  </div>
 </div>


### PR DESCRIPTION
## 関連するissue
close #74

## 概要
以下を実行しました。

・ユーザー詳細画面にフォロー・フォロワーの一覧を表示
・ユーザー詳細画面からユーザーを名前かメールアドレスから検索できるように変更

## 確認事項
特になし

## 確認方法
ユーザー詳細画面にアクセスしてもらうことで確認できます。

## 懸念点
特になし。

## 参考記事
特になし。