### PR TITLE
アルバム詳細ページでのヘッダーを追加・ページ内リンクの追加

### DIFF
--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -22,10 +22,33 @@
         </div>
       </div>
     </div>
+    <div class="grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3"> 
+      <div class='text-center py-2'>
+        <button class="btn btn-outline btn-primary">
+          <%= link_to anchor: "event_top" do %>
+            <i class="fa-solid fa-plane fa-lg"></i>イベントへ移動
+          <% end %>
+        </button>
+      </div>
+      <div class='text-center py-2'>
+        <button class="btn btn-outline btn-secondary">
+        <%= link_to anchor: "rank_top" do %>
+            <i class="fa-solid fa-ranking-star fa-lg"></i>ランキングへ移動
+          <% end %>
+        </button>
+      </div>
+      <div class='text-center py-2'>
+        <button class="btn btn-outline btn-accent">
+        <%= link_to anchor: "suprise_top" do %>
+            <i class="fa-solid fa-gift fa-lg"></i>サプライズメッセージへ移動
+          <% end %>
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 <!-- message for everyone -->
-<h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 underline">メンバー</h2>
+<h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6 underline pt-8">メンバー</h2>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
     <!-- text - start -->
@@ -67,18 +90,18 @@
 </div>
 <div class="bg-white py-6 sm:py-8 lg:py-12">
   <div class="max-w-screen-xl px-4 md:px-8 mx-auto">
-    <div class="mb-10 md:mb-16">
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">思い出の行事</h2>
+    <div class="mb-10 md:mb-16" id='event_top'>
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6"><i class="fa-solid fa-plane fa-lg"></i>思い出の行事</h2>
       <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">みんなとの楽しい思い出を共有しよう</p>
     </div>
     <%= render 'events/events', { graduation_album: @graduation_album, events: @events } %>
-    <div class="mb-10 md:mb-16">
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">メンバーランキング</h2>
+    <div class="mb-10 md:mb-16" id='rank_top'>
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6"><i class="fa-solid fa-ranking-star fa-lg"></i>メンバーランキング</h2>
       <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">〇〇になりそうな人ランキングを作成しよう</p>
     </div>
     <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks} %>
-    <div class="mb-10 md:mb-16">
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6">サプライズメッセージ</h2>
+    <div class="mb-10 md:mb-16" id='suprise_top'>
+      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6"><i class="fa-solid fa-gift fa-lg"></i>サプライズメッセージ</h2>
       <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto">未来に向けてメッセージを残そう</p>
     </div>
     <%= render 'suprise_messages/suprise_messages', { graduation_album: @graduation_album, suprise_messages: @suprise_messages } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,10 +13,12 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
-    <% if user_signed_in? %>
+    <% if user_signed_in? != true %>
+      <%= render 'shared/before_login_header' %>
+    <% elsif request.path == '/users/show' || request.path == '/graduation_albums' || request.path == '/' %>
       <%= render 'shared/header' %>
     <% else %>
-      <%= render 'shared/before_login_header' %>
+      <%= render 'shared/album_header'%>
     <% end %>
     <%= render 'shared/flash' %>
     <div class='flex-grow'>

--- a/app/views/shared/_album_header.html.erb
+++ b/app/views/shared/_album_header.html.erb
@@ -1,0 +1,41 @@
+<header>
+  <div class="navbar bg-green-100">
+    <div class="flex-1">
+      <%= link_to 'Web卒アル', graduation_albums_path, class:"btn btn-ghost normal-case text-xl" %>
+    </div>
+    <div class="flex-none">
+      <ul class="menu menu-horizontal p-0">
+        <li>
+          <%= link_to anchor: "event_top" do %>
+            <i class="fa-solid fa-plane fa-lg"></i>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to anchor: "rank_top" do %>
+            <i class="fa-solid fa-ranking-star fa-lg"></i>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to anchor: "suprise_top" do %>
+            <i class="fa-solid fa-gift fa-lg"></i>
+          <% end %>
+        </li>
+      </ul>
+      <div class="dropdown dropdown-end" id='profile'>
+        <label tabindex="0" class="btn btn-ghost btn-circle avatar">
+          <div class="w-10 rounded-full">
+            <%= image_tag current_user.avatar.to_s %>
+          </div>
+        </label>
+        <ul tabindex="0" class="menu menu-compact dropdown-content mt-3 p-2 shadow bg-base-100 rounded-box w-52">
+          <li>
+            <a class="justify-between">
+              <%= link_to "プロフィール", users_show_path %>
+            </a>
+          </li>
+          <li><%= link_to "ログアウト", logout_path %></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</header>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,7 +1,7 @@
 <header>
   <div class="navbar bg-green-100">
     <div class="flex-1">
-      <%= link_to 'Web卒アル', graduation_albums_path, class:"btn btn-ghost normal-case text-xl" %>
+    <%= link_to 'Web卒アル', graduation_albums_path, class:"btn btn-ghost normal-case text-xl" %>
     </div>
     <div class="flex-none">
       <div class="dropdown dropdown-end" id='profile'>

--- a/app/views/suprise_messages/_suprise_message.html.erb
+++ b/app/views/suprise_messages/_suprise_message.html.erb
@@ -17,15 +17,15 @@
         <%= suprise_message.suprise_message%>
       </div>
   <div class="grid grid-cols-8" >
-    <div class='flex items-center col-end-9 col-span-1'>
+    <div class='flex items-center col-end-9 col-span-3'>
       <div class="avatar ">
         <div class="w-12 rounded-full ">
           <%= link_to graduation_album_menber_path(suprise_message.graduation_album,suprise_message.user) do %>
             <%= image_tag current_user.avatar.to_s %>
           <% end %>
         </div>
+        <%= link_to suprise_message.user.name, graduation_album_menber_path(suprise_message.graduation_album, suprise_message.user), class: "px-4 text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
       </div>
-      <%= link_to suprise_message.user.name, graduation_album_menber_path(suprise_message.graduation_album, suprise_message.user), class: "px-4 text-gray-800 hover:text-gray-500 text-lg lg:text-xl font-bold transition duration-100"%>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 関連するissue
close #90 
close #89

## 概要
以下を実行しました。

・アルバム詳細画面にアクセスした場合のヘッダーを新たに作成
・アルバム詳細ページにイベント、ランキング、サプライズメッセージへのページ内リンクを追加

## 確認事項
特になし

## 確認方法
アルバム詳細画面にアクセスしてもらうことで確認できます。

## 懸念点
特になし。

## 参考記事
特になし。