### PR TITLE
アルバム詳細画面に表示される写真をレスポンシブに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use Active Storage variant
-# gem 'image_processing', '~> 1.2'
+gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   gretel
+  image_processing (~> 1.2)
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)

--- a/app/assets/javascripts/swiper.js
+++ b/app/assets/javascripts/swiper.js
@@ -3,7 +3,6 @@ document.addEventListener('DOMContentLoaded', function() {
   // Optional parameters
   loop: true,
   loopAdditionalSlides: 1,
-
   //アニメーションで動くように設定
   speed: 700,
   autoplay: {
@@ -18,8 +17,13 @@ document.addEventListener('DOMContentLoaded', function() {
     nextEl: '.swiper-button-next',
     prevEl: '.swiper-button-prev',
   },
-
-  slidesPerView: 3,
+  slidesPerView: 1.35,
+  breakpoints: {
+    // スライドの表示枚数：500px以上の場合
+    500: {
+      slidesPerView: 2.75,
+    },
+  },
   spaceBetween: 30,
   centeredSlides: true,
   pagination: {
@@ -33,7 +37,22 @@ document.addEventListener('DOMContentLoaded', function() {
   const loopSwiper = new Swiper('.loopSwiper', {
   spaceBetween: 5,
   loop: true, // ループ有効
-  slidesPerView: 5, // 一度に表示する枚数
+  slidesPerView: 2,
+  breakpoints: {
+    // スライドの表示枚数：500px以上の場合
+    500: {
+      slidesPerView: 3,
+    },
+    700: {
+      slidesPerView: 4,
+    },
+    900: {
+      slidesPerView: 5,
+    },
+    1100: {
+      slidesPerView: 6,
+    }
+  },
   speed: 8000, // ループの時間
   allowTouchMove: false, // スワイプ無効
   autoplay: {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -21,15 +21,6 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 @import '@fortawesome/fontawesome-free/scss/v4-shims';
 @import 'swiper/swiper-bundle.min.css';
 
-#album-swiper {
-  height: 400px;
-}
-
-#album-swiper>img {
-  object-fit: cover;
-  width: 100%;
-  height: 100%;
-}
 
 #loop-swiper {
   height: 200px;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,7 +18,7 @@ class EventsController < ApplicationController
   end
 
   def show
-    @event = Event.with_attached_event_photos.find(params[:id])
+    @event = Event.find(params[:id])
     @event_comments = @event.event_comments.order(created_at: :desc)
     @event_comment = EventComment.new
   end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -10,7 +10,7 @@
           <div class="w-full sm:w-1/2 lg:w-2/5 h-48 sm:h-auto order-first sm:order-none bg-gray-300">
             <%= link_to graduation_album_event_path(event.graduation_album, event) do %>
               <% event.event_photos.each do |photo| %>
-                <%= image_tag photo %>
+                <%= image_tag photo, class:'object-contai'%>
               <% end %>
             <% end %>
           </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,52 +1,16 @@
 <% breadcrumb :event_show, @event.graduation_album, @event %>
-<div class="py-6 sm:py-8 lg:py-12">
-  <div class="max-w-screen-2xl px-4 md:px-8 mx-auto">
-    <!-- text - start -->
-    <div class="mb-10 md:mb-16">
-      <h2 class="text-gray-800 text-2xl lg:text-3xl font-bold text-center mb-4 md:mb-6"><%= @event.title %></h2>
 
-      <p class="max-w-screen-md text-gray-500 md:text-lg text-center mx-auto"><%= @event.description %></p>
+<!-- component -->
+<div class="flex items-center justify-center h-screen bg-gray-200">
+  <div class="container">
+    <div class="bg-white rounded-lg shadow-lg p-5 md:p-20 mx-2">
+      <div class="text-center">
+        <h2 class="text-4xl tracking-tight leading-10 font-extrabold text-gray-900 sm:text-5xl sm:leading-none md:text-6xl">
+          とてもおしゃれなイベント詳細ページ</span>
+        </h2>
+        <h3 class='text-xl md:text-3xl mt-10'>Coming Soon</h3>
+        <p class="text-md md:text-xl mt-10"><a class="hover:underline" href="https://www.quicktoolz.com">本リリースで実装予定です</p>
+      </div>
     </div>
-    <!-- text - end -->
-    <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 md:gap-6 xl:gap-8">
-      <!-- image - start -->
-      <!-- image - end -->
-      <!-- image - start -->
-
-      <% if @event.event_photos %>
-        <% @event.event_photos.each_with_index do |photo, ind| %> 
-          <% if ind.even? %>
-            <!-- image - start -->
-            <div class="group h-48 md:h-80 flex bg-gray-100 overflow-hidden rounded-lg shadow-lg relative" >
-              <%= image_tag 'suika.png'%>
-            </div>
-            <a href="#" class="group h-48 md:h-80 md:col-span-2 flex items-end bg-gray-100 overflow-hidden rounded-lg shadow-lg relative">
-            <div class='photo w-full h-full object-cover object-center absolute inset-0'>
-              <%= image_tag photo%>
-              <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
-            </div>
-            </a>
-            <!-- image - end -->
-          <% else %>
-            <!-- image - start -->
-            <a href="#" class="group h-48 md:h-80 md:col-span-2 flex items-end bg-gray-100 overflow-hidden rounded-lg shadow-lg relative">
-              <div class='photo w-full h-full object-cover object-center absolute inset-0'>
-              <%= image_tag photo%>
-              <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
-            </div>
-              <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
-            </a>
-            <div class="group h-48 md:h-80 flex bg-gray-100 overflow-hidden rounded-lg shadow-lg relative" >
-              <%= image_tag 'furin.png'%>
-            </div>
-            <!-- image - end -->
-          <% end %>
-        <% end %>
-      <% end %>
-      <!-- image - end -->
-    </div>
-    <%= render 'event_comments/event_comments', { event_comments: @event_comments } %>
-<%= render 'event_comments/form', { graduation_album: @graduation_album, event_comment: @event_comment } %>
   </div>
-  
 </div>

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -10,7 +10,7 @@
               <div class="swiper mySwiper">
                 <div class="swiper-wrapper">
                   <% @graduation_album.images.each do |image| %> 
-                    <%= image_tag image, class:"swiper-slide rounded-lg", size: '320x240', id:"album-swiper" %>
+                    <%= image_tag image.variant(gravity: :center, resize:"600x600^", crop:"600x600+0+0").processed, class:"swiper-slide rounded-lg", id:"album-swiper" %>
                   <% end %>
                 </div><!-- .swiper-wrapper -->
                   <div class="swiper-pagination"></div>
@@ -82,7 +82,7 @@
     <div class="swiper loopSwiper">
       <div class="swiper-wrapper">
         <% @graduation_album.images.each do |image| %>
-          <%= image_tag image, class:"swiper-slide rounded-lg", id:"loop-swiper", size: '320x240' %>
+          <%= image_tag image, class:"swiper-slide rounded-lg", id:"loop-swiper" %>
         <% end %>
       </div>
     </div>


### PR DESCRIPTION
## 関連するissue
close #91

## 概要
以下を実行しました。

・アルバム詳細画面に表示される画像をレスポンシブに変更

## 確認事項
特になし

## 確認方法
スマホ画面とPC画面でアルバム詳細画面にアクセスすることで確認できます

## 懸念点
特になし。

## 参考記事
特になし。