### PR TITLE
モデルスペックを自動実行するCircleCIを導入

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.1.2-node
+      - image: cimg/ruby:3.1.2-node-browsers
     steps:
       - checkout
       - ruby/install-deps
@@ -16,7 +16,7 @@ jobs:
   test:
     parallelism: 3
     docker:
-      - image: cimg/ruby:3.1.2-node
+      - image: cimg/ruby:3.1.2-node-browsers
       - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: tsunemiyuusuke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,4 @@
 version: 2.1
-
 orbs:
   ruby: circleci/ruby@1.1.0
   node: circleci/node@2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
       - run: 
           name: Setup Chrome
           command: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget https://dl.google.com/linux/direct/google-chrome-stable
             sudo apt install google-chrome-stable
       - run:
           name: Rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,6 @@ jobs:
       - run:
           name: Database setup
           command: bundle exec rails db:schema:load --trace
-      - run: 
-          google-chrome --version
       - run:
           name: Rspec
           command: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,8 @@ jobs:
       - run: 
           name: Setup Chrome
           command: |
-            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
-            echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
-            apt update -y
-            apt install -y google-chrome-stable
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo apt install google-chrome-stable
       - run:
           name: Rspec
           command: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,14 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@1.1.0
   node: circleci/node@2
+  browser-tools: circleci/browser-tools@1.1
 
 jobs:
   build:
     docker:
-      - image: cimg/ruby:3.1.2-node-browsers
+      - image: cimg/ruby:3.1.2-browsers
     steps:
+      - browser-tools/install-browser-tools
       - checkout
       - ruby/install-deps
       - node/install-packages:
@@ -16,7 +18,7 @@ jobs:
   test:
     parallelism: 3
     docker:
-      - image: cimg/ruby:3.1.2-node-browsers
+      - image: cimg/ruby:3.1.2-browsers
       - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: tsunemiyuusuke
@@ -42,10 +44,7 @@ jobs:
           name: Database setup
           command: bundle exec rails db:schema:load --trace
       - run: 
-          name: Setup Chrome
-          command: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable
-            sudo apt install google-chrome-stable
+          google-chrome --version
       - run:
           name: Rspec
           command: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,8 +44,10 @@ jobs:
       - run: 
           name: Setup Chrome
           command: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-            sudo apt install ./google-chrome-stable_current_amd64.deb
+            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+            echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+            apt update -y
+            apt install -y google-chrome-stable
       - run:
           name: Rspec
           command: bundle exec rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,11 @@ jobs:
       - run:
           name: Database setup
           command: bundle exec rails db:schema:load --trace
+      - run: 
+          name: Setup Chrome
+          command: |
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            sudo apt install ./google-chrome-stable_current_amd64.deb
       - run:
           name: Rspec
           command: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ config/environments/*.local.yml
 coverage/*
 
 # Ignore database.yml for local
-config/database.yml
+
 
 .solargraph.yml
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,89 @@
+# PostgreSQL. Versions 9.3 and up are supported.
+#
+# Install the pg driver:
+#   gem install pg
+# On macOS with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On macOS with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+
+development:
+  <<: *default
+  database: album_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user running Rails.
+  #username: album
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: album_test
+
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password or a full connection URL as an environment
+# variable when you boot the app. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# If the connection URL is provided in the special DATABASE_URL environment
+# variable, Rails will automatically merge its configuration values on top of
+# the values provided in this file. Alternatively, you can specify a connection
+# URL environment variable explicitly:
+#
+#   production:
+#     url: <%= ENV['MY_APP_DATABASE_URL'] %>
+#
+# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full overview on how database connection configuration can be specified.
+#
+production:
+  <<: *default
+  database: album_production
+  username: album
+  password: <%= ENV['ALBUM_DATABASE_PASSWORD'] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -21,7 +21,7 @@
 require 'rails_helper'
 
 RSpec.describe GraduationAlbum, type: :model do
-  fdescribe 'バリデーション' do
+  describe 'バリデーション' do
     it 'アルバム名が存在し、どちらも255字以内の場合有効であること' do
       graduation_album = build(:graduation_album)
       expect(graduation_album).to be_valid

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -21,7 +21,7 @@
 require 'rails_helper'
 
 RSpec.describe GraduationAlbum, type: :model do
-  describe 'バリデーション' do
+  fdescribe 'バリデーション' do
     it 'アルバム名が存在し、どちらも255字以内の場合有効であること' do
       graduation_album = build(:graduation_album)
       expect(graduation_album).to be_valid


### PR DESCRIPTION
## 関連するissue
特になし

## 概要
以下を実行しました。

・circle ciの導入
・pushしたらmodelスペックを実行するように設定
・circle ciを実行するためにdatabase.ymlをgitignoreの対象から削除


## 確認方法
pushを行うことで確認できます。

## 懸念点
システムスペックは自動化できなかったので修正が必要

## 参考記事
特になし。