### PR TITLE
自動ランキング作成機能を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,11 +59,11 @@ Metrics/LineLength:
 # メソッドの行数を20行までにする
 Metrics/MethodLength:
   CountComments: false
-  Max: 45
+  Max: 48
 
 # ABC sizeは緩めにする
 Metrics/AbcSize:
-  Max: 60 # default 15
+  Max: 64 # default 15
 
 Metrics/PerceivedComplexity:
   Max: 10

--- a/app/controllers/auto_make_ranks_controller.rb
+++ b/app/controllers/auto_make_ranks_controller.rb
@@ -4,7 +4,7 @@ class AutoMakeRanksController < ApplicationController
       flash[:danger] = 'イベント作成するためには写真を追加してください'
       redirect_back(fallback_location: root_path)
     else
-			#既にhappy_scoreが設定されているものは除外する
+      # 既にhappy_scoreが設定されているものは除外する
       having_face_images = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).where(happy_score: nil)
       if having_face_images
         credentials = Aws::Credentials.new(
@@ -24,10 +24,10 @@ class AutoMakeRanksController < ApplicationController
           }
           result = client.detect_faces attrs
           number = if result.to_h[:face_details].length > 5
-                    5
-                  else
-                    result.to_h[:face_details].length
-                  end
+                     5
+                   else
+                     result.to_h[:face_details].length
+                   end
           happy_score_count = 0
           number.times do |count|
             happy_score_count += result.to_h[:face_details][count][:emotions][0][:confidence].round
@@ -43,8 +43,8 @@ class AutoMakeRanksController < ApplicationController
       else
         @rank = Rank.create!(rank_title: 'ハッピー写真ランキング', rank_description: 'アルバムに投稿された写真から笑顔の写真を抜粋しました！みんなの笑顔の写真を見て癒されましょう！', user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
         happy_photos.each do |photo|
-					rank_choice = RankChoice.create!(content: "#{photo.happy_score}点の笑顔です！", rank_id: @rank.id)
-					ActiveStorage::Attachment.create!(name: 'rank_choice_image', record_type: 'RankChoice', record_id: rank_choice.id, blob_id: photo.path.to_i)
+          rank_choice = RankChoice.create!(content: "#{photo.happy_score}点の笑顔です！", rank_id: @rank.id)
+          ActiveStorage::Attachment.create!(name: 'rank_choice_image', record_type: 'RankChoice', record_id: rank_choice.id, blob_id: photo.path.to_i)
         end
         redirect_to graduation_album_rank_path(@rank.graduation_album, @rank), notice: 'イベントを作成しました'
       end

--- a/app/controllers/auto_make_ranks_controller.rb
+++ b/app/controllers/auto_make_ranks_controller.rb
@@ -1,0 +1,53 @@
+class AutoMakeRanksController < ApplicationController
+  def create
+    if GraduationAlbum.find(params[:graduation_album_id]).images_blobs == []
+      flash[:danger] = 'イベント作成するためには写真を追加してください'
+      redirect_back(fallback_location: root_path)
+    else
+			#既にhappy_scoreが設定されているものは除外する
+      having_face_images = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).where(happy_score: nil)
+      if having_face_images
+        credentials = Aws::Credentials.new(
+          ENV.fetch('AWS_ACCESS_KEY_ID', nil),
+          ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
+        )
+        client = Aws::Rekognition::Client.new credentials: credentials
+        having_face_images.each do |image|
+          attrs = {
+            image: {
+              s3_object: {
+                bucket: 'aws-test-rails',
+                name: image.s3_file_name
+              }
+            },
+            attributes: ['ALL']
+          }
+          result = client.detect_faces attrs
+          number = if result.to_h[:face_details].length > 5
+                    5
+                  else
+                    result.to_h[:face_details].length
+                  end
+          happy_score_count = 0
+          number.times do |count|
+            happy_score_count += result.to_h[:face_details][count][:emotions][0][:confidence].round
+          end
+          image.happy_score = happy_score_count
+          image.save!
+        end
+      end
+      happy_photos = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).order(happy_score: 'DESC').limit(3)
+      if happy_photos == []
+        flash[:danger] = 'イベントの作成に失敗しました 笑顔の写真を追加してください'
+        redirect_back(fallback_location: root_path)
+      else
+        @rank = Rank.create!(rank_title: 'ハッピー写真ランキング', rank_description: 'アルバムに投稿された写真から笑顔の写真を抜粋しました！みんなの笑顔の写真を見て癒されましょう！', user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
+        happy_photos.each do |photo|
+					rank_choice = RankChoice.create!(content: "#{photo.happy_score}点の笑顔です！", rank_id: @rank.id)
+					ActiveStorage::Attachment.create!(name: 'rank_choice_image', record_type: 'RankChoice', record_id: rank_choice.id, blob_id: photo.path.to_i)
+        end
+        redirect_to graduation_album_rank_path(@rank.graduation_album, @rank), notice: 'イベントを作成しました'
+      end
+    end
+  end
+end

--- a/app/controllers/rank_choices_controller.rb
+++ b/app/controllers/rank_choices_controller.rb
@@ -37,6 +37,6 @@ class RankChoicesController < ApplicationController
   private
 
   def set_rank_choice
-    params.require(:rank_choice).permit(:content).merge(rank_id: params[:rank_id])
+    params.require(:rank_choice).permit(:content, rank_choice_images: []).merge(rank_id: params[:rank_id])
   end
 end

--- a/app/controllers/rank_choices_controller.rb
+++ b/app/controllers/rank_choices_controller.rb
@@ -37,6 +37,6 @@ class RankChoicesController < ApplicationController
   private
 
   def set_rank_choice
-    params.require(:rank_choice).permit(:content, rank_choice_images: []).merge(rank_id: params[:rank_id])
+    params.require(:rank_choice).permit(:content, rank_choice_image: []).merge(rank_id: params[:rank_id])
   end
 end

--- a/app/controllers/ranks_controller.rb
+++ b/app/controllers/ranks_controller.rb
@@ -20,7 +20,6 @@ class RanksController < ApplicationController
 
   def show
     @rank = Rank.find(params[:id])
-    @rank_choices = @rank.rank_choices
   end
 
   def update

--- a/app/models/rank_choice.rb
+++ b/app/models/rank_choice.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (rank_id => ranks.id)
 #
 class RankChoice < ApplicationRecord
-  has_many_attached :rank_choice_images
+  has_one_attached :rank_choice_image
   belongs_to :rank
   has_many :answers, dependent: :destroy
 

--- a/app/models/rank_choice.rb
+++ b/app/models/rank_choice.rb
@@ -18,6 +18,7 @@
 #  fk_rails_...  (rank_id => ranks.id)
 #
 class RankChoice < ApplicationRecord
+  has_many_attached :rank_choice_images
   belongs_to :rank
   has_many :answers, dependent: :destroy
 

--- a/app/views/graduation_albums/show.html.erb
+++ b/app/views/graduation_albums/show.html.erb
@@ -117,9 +117,10 @@
     </div>
     
     <div class="mb-10 md:mb-16" id='rank_top'>
-      <h2 class="text-pink-500 text-2xl lg:text-3xl font-bold text-center mb-6 mt-12 md:mb-6"><i class="fa-solid fa-ranking-star fa-lg"></i> メンバーランキング</h2>
+      <h2 class="text-pink-500 text-2xl lg:text-3xl font-bold text-center mb-3 mt-6 md:mb-3"><i class="fa-solid fa-ranking-star fa-lg"></i> メンバーランキング</h2>
       <p class="max-w-screen-md text-pink-500 md:text-lg text-center mx-auto">〇〇になりそうな人ランキングを作成しよう</p>
     </div>
+    <div class='py-2 text-center'><button class="btn btn-outline btn-secondary"><%= link_to 'ランキングを自動で作成する', graduation_album_auto_make_ranks_path(@graduation_album), method: :post %></div>
     <% if @ranks != [] %>
       <%= render 'ranks/ranks', { graduation_album: @graduation_album, ranks: @ranks} %>
     <% else %>

--- a/app/views/rank_choices/edit.html.erb
+++ b/app/views/rank_choices/edit.html.erb
@@ -5,6 +5,10 @@
       <%= f.label :content, class: "text-sm block"%>
       <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "選択肢" %>
     </div>
+    <div class="mb-8">
+      <%= f.label :rank_choice_image, class: "text-sm block"%>
+      <%= f.file_field :rank_choice_image, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50' %>
+    </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>
     </div>

--- a/app/views/rank_choices/new.html.erb
+++ b/app/views/rank_choices/new.html.erb
@@ -5,6 +5,10 @@
       <%= f.label :content, class: "text-sm block"%>
       <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "選択肢" %>
     </div>
+    <div class="mb-8">
+      <%= f.label :rank_choice_images, class: "text-sm block"%>
+      <%= f.file_field :rank_choice_images, multiple: true, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50' %>
+    </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>
     </div>

--- a/app/views/rank_choices/new.html.erb
+++ b/app/views/rank_choices/new.html.erb
@@ -6,8 +6,8 @@
       <%= f.text_field :content, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50', placeholder: "選択肢" %>
     </div>
     <div class="mb-8">
-      <%= f.label :rank_choice_images, class: "text-sm block"%>
-      <%= f.file_field :rank_choice_images, multiple: true, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50' %>
+      <%= f.label :rank_choice_image, class: "text-sm block"%>
+      <%= f.file_field :rank_choice_image, class: 'w-full py-2 border-b focus:outline-none focus:border-b-2 focus:border-indigo-500 placeholder-gray-500 placeholder-opacity-50' %>
     </div>
     <div class='form-control mt-6'>
       <%= f.submit '作成する', class: 'btn btn-primary' %>

--- a/app/views/ranks/_rank.html.erb
+++ b/app/views/ranks/_rank.html.erb
@@ -23,6 +23,7 @@
       </div>
     </div>
     <% rank.rank_choices.order(answers_count: 'DESC').with_attached_rank_choice_image.each_with_index do |choice, index| %>
+    <% if choice.rank_choice_image.variant( rotate: 2 )  %>
       <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative py-4">
             <% if index.even? %>
               <%= image_tag choice.rank_choice_image.variant( rotate: 2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
@@ -31,6 +32,7 @@
             <% end %>
               <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
             </div>
+    <% end %>
       <div class="flex items-center my-4">
         <div class="grid grid-cols-12 flex items-center mt-4">
           <span class="col-span-2 text-sm font-medium text-pink-500 dark:text-blue-500"><%= choice.content %></span>

--- a/app/views/ranks/_rank.html.erb
+++ b/app/views/ranks/_rank.html.erb
@@ -22,8 +22,16 @@
         </div>
       </div>
     </div>
-    <% rank.rank_choices.order(answers_count: 'DESC').each do |choice| %>
-      <div class="flex items-center mt-4">
+    <% rank.rank_choices.order(answers_count: 'DESC').with_attached_rank_choice_image.each_with_index do |choice, index| %>
+      <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative py-4">
+            <% if index.even? %>
+              <%= image_tag choice.rank_choice_image.variant( rotate: 2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
+            <% else %>
+              <%= image_tag choice.rank_choice_image.variant( rotate: -2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
+            <% end %>
+              <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
+            </div>
+      <div class="flex items-center my-4">
         <div class="grid grid-cols-12 flex items-center mt-4">
           <span class="col-span-2 text-sm font-medium text-pink-500 dark:text-blue-500"><%= choice.content %></span>
           <div class="self-center col-span-7 h-5 mx-4 bg-gray-200 rounded dark:bg-gray-700">

--- a/app/views/ranks/show.html.erb
+++ b/app/views/ranks/show.html.erb
@@ -38,6 +38,12 @@
               <% end %>
             </span>
           </div>
+          <% choice.rank_choice_images.each do |image| %> 
+              <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative p-4">
+                <%= image_tag image, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 group-hover:scale-110 transition duration-200" %>
+                <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
+              </div>
+            <% end %>
         <% end %>
         <div class='pt-6'>
           <button class="btn btn-outline"><%= link_to '選択肢を追加', new_graduation_album_rank_rank_choice_path(@rank.graduation_album, @rank) %></button>
@@ -46,3 +52,4 @@
     </div>
   </div>
 </div>
+

--- a/app/views/ranks/show.html.erb
+++ b/app/views/ranks/show.html.erb
@@ -19,8 +19,16 @@
           </div>
           <%= simple_format(@rank.rank_description) %>
         </div>
-        <% @rank.rank_choices.order(answers_count: "DESC").each do |choice| %>
-          <div class="grid grid-cols-12 flex items-center mt-4">
+        <% @rank.rank_choices.order(answers_count: "DESC").with_attached_rank_choice_image.each_with_index do |choice, index| %>
+            <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative p-4">
+            <% if index.even? %>
+              <%= image_tag choice.rank_choice_image.variant( rotate: 2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
+            <% else %>
+              <%= image_tag choice.rank_choice_image.variant( rotate: -2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
+            <% end %>
+              <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
+            </div>
+          <div class="grid grid-cols-12 flex items-center my-4">
             <div class="text-2xl col-span-3 text-sm font-medium text-blue-600 dark:text-blue-500 text-center">
               <i class="fa-solid fa-crown"></i> <%= choice.content %>
             </div>
@@ -38,12 +46,6 @@
               <% end %>
             </span>
           </div>
-          <% choice.rank_choice_images.each do |image| %> 
-              <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative p-4">
-                <%= image_tag image, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 group-hover:scale-110 transition duration-200" %>
-                <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
-              </div>
-            <% end %>
         <% end %>
         <div class='pt-6'>
           <button class="btn btn-outline"><%= link_to '選択肢を追加', new_graduation_album_rank_rank_choice_path(@rank.graduation_album, @rank) %></button>

--- a/app/views/ranks/show.html.erb
+++ b/app/views/ranks/show.html.erb
@@ -20,6 +20,7 @@
           <%= simple_format(@rank.rank_description) %>
         </div>
         <% @rank.rank_choices.order(answers_count: "DESC").with_attached_rank_choice_image.each_with_index do |choice, index| %>
+        <% if choice.rank_choice_image.variant( rotate: 2 )  %>
             <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative p-4">
             <% if index.even? %>
               <%= image_tag choice.rank_choice_image.variant( rotate: 2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
@@ -28,6 +29,7 @@
             <% end %>
               <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
             </div>
+        <% end %>
           <div class="grid grid-cols-12 flex items-center my-4">
             <div class="text-2xl col-span-3 text-sm font-medium text-blue-600 dark:text-blue-500 text-center">
               <i class="fa-solid fa-crown"></i> <%= choice.content %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Rails.application.routes.draw do
     resources :message_for_each_menbers, only: %i[create edit destroy update]
     resources :suprise_messages, only: %i[create edit destroy update new show]
     resources :auto_make_events, only: %i[create]
+    resources :auto_make_ranks, only: %i[create]
   end
   resources :answers, only: %i[create]
   resources :relationships, only: %i[create destroy]


### PR DESCRIPTION
## 関連するissue
close #131 

## 概要
以下を実行しました。

・ランキングを自動で作成する機能を追加
アルバムに投稿された画像の中から笑顔のスコアが高い写真を上位3つ取得し、ランキングを作成する。

## 確認方法
自動作成ボタンを押すと自動でイベントが作成されます。

## 懸念点
特になし。

## 参考記事
特になし。