### PR TITLE
Delete: 独自ドメインからもauth0を使用できるように設定を削除#152

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -4,7 +4,6 @@ require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
   config.action_controller.asset_host = 'https://d3qnuxipfve71d.cloudfront.net'
-  OmniAuth.config.full_host = 'https://web-album.herokuapp.com'
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.


### PR DESCRIPTION
## 関連するissue
close #152 

## 概要
以下を実行しました。

・独自ドメインカラムauth0が使用できるように設定を変更

## 確認事項
特になし

## 確認方法
本番環境の使用なのでデプロイ後に確認

## 懸念点
特になし。

## 参考記事
特になし。