### PR TITLE
Fix rekognition bug

### DIFF
--- a/app/controllers/auto_make_events_controller.rb
+++ b/app/controllers/auto_make_events_controller.rb
@@ -39,7 +39,7 @@ class AutoMakeEventsController < ApplicationController
         flash[:danger] = 'イベントの作成に失敗しました 笑顔の写真を追加してください'
         redirect_back(fallback_location: root_path)
       else
-        @event = Event.create!(title: 'ハッピー写真集', description: 'アルバムに投稿された写真から笑顔の写真を抜粋しました！みんなの笑顔の写真を見て癒されましょう！', event_date: Date.today, user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
+        @event = Event.create!(title: 'みんなの笑顔集', description: 'アルバムに投稿された写真から笑顔の写真を抜粋しました！みんなの笑顔の写真を見て癒されましょう！', event_date: Date.today, user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
         happy_photo_ids.each do |id|
           ActiveStorage::Attachment.create!(name: 'event_photos', record_type: 'Event', record_id: @event.id, blob_id: id)
         end

--- a/app/controllers/auto_make_ranks_controller.rb
+++ b/app/controllers/auto_make_ranks_controller.rb
@@ -36,14 +36,14 @@ class AutoMakeRanksController < ApplicationController
           image.save!
         end
       end
-      happy_photos = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).order(happy_score: 'DESC').where("happy_score > ?", 90).limit(3)
+      happy_photos = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).order(happy_score: 'DESC').where('happy_score > ?', 90).limit(3)
       if happy_photos == []
         flash[:danger] = 'イベントの作成に失敗しました 幸せそうな写真を追加してください'
         redirect_back(fallback_location: root_path)
       else
         @rank = Rank.create!(rank_title: '幸せな写真ランキング', rank_description: 'アルバムに投稿された写真から幸福度の高い写真を抜粋しました！みんなの幸せな顔を見て癒されましょう！', user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
         happy_photos.each do |photo|
-          rank_choice = RankChoice.create!(content: "最高の笑顔です！", rank_id: @rank.id)
+          rank_choice = RankChoice.create!(content: '最高の笑顔です！', rank_id: @rank.id)
           ActiveStorage::Attachment.create!(name: 'rank_choice_image', record_type: 'RankChoice', record_id: rank_choice.id, blob_id: photo.path.to_i)
         end
         redirect_to graduation_album_rank_path(@rank.graduation_album, @rank), notice: 'イベントを作成しました'

--- a/app/controllers/auto_make_ranks_controller.rb
+++ b/app/controllers/auto_make_ranks_controller.rb
@@ -36,14 +36,14 @@ class AutoMakeRanksController < ApplicationController
           image.save!
         end
       end
-      happy_photos = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).order(happy_score: 'DESC').limit(3)
+      happy_photos = PhotoPath.where(graduation_album_id: params[:graduation_album_id]).order(happy_score: 'DESC').where("happy_score > ?", 90).limit(3)
       if happy_photos == []
-        flash[:danger] = 'イベントの作成に失敗しました 笑顔の写真を追加してください'
+        flash[:danger] = 'イベントの作成に失敗しました 幸せそうな写真を追加してください'
         redirect_back(fallback_location: root_path)
       else
-        @rank = Rank.create!(rank_title: 'ハッピー写真ランキング', rank_description: 'アルバムに投稿された写真から笑顔の写真を抜粋しました！みんなの笑顔の写真を見て癒されましょう！', user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
+        @rank = Rank.create!(rank_title: '幸せな写真ランキング', rank_description: 'アルバムに投稿された写真から幸福度の高い写真を抜粋しました！みんなの幸せな顔を見て癒されましょう！', user_id: current_user.id, graduation_album_id: params[:graduation_album_id])
         happy_photos.each do |photo|
-          rank_choice = RankChoice.create!(content: "#{photo.happy_score}点の笑顔です！", rank_id: @rank.id)
+          rank_choice = RankChoice.create!(content: "最高の笑顔です！", rank_id: @rank.id)
           ActiveStorage::Attachment.create!(name: 'rank_choice_image', record_type: 'RankChoice', record_id: rank_choice.id, blob_id: photo.path.to_i)
         end
         redirect_to graduation_album_rank_path(@rank.graduation_album, @rank), notice: 'イベントを作成しました'

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,6 +8,7 @@ class EventsController < ApplicationController
 
   def create
     @event = current_user.events.build(event_params)
+    @graduation_album = GraduationAlbum.find(params[:graduation_album_id])
     if @event.save
       redirect_to graduation_album_event_path(@event.graduation_album, @event), notice: 'コメントを投稿しました'
     else

--- a/app/controllers/menbers_controller.rb
+++ b/app/controllers/menbers_controller.rb
@@ -6,7 +6,7 @@ class MenbersController < ApplicationController
     @graduation_album = current_user.belong_albums.find(params[:graduation_album_id])
     @menber = User.find(params[:id])
     collection_id = 'graduation_album'
-    if @menber.face_id && @menber.registered_collections.pluck(:collection_name).include?(collection_id.to_s)
+    if @menber.face_id && @graduation_album.analysis_status == 'done' && @menber.registered_collections.pluck(:collection_name).include?(collection_id.to_s)
       credentials = Aws::Credentials.new(
         ENV.fetch('AWS_ACCESS_KEY_ID', nil),
         ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
@@ -28,7 +28,7 @@ class MenbersController < ApplicationController
         @mathed_face_images = []
         mathed_faces.each do |image|
           photo_path = PhotoPath.where(graduation_album_id: @graduation_album.id).where(image_id: image).first
-          @mathed_face_images.push(ActiveStorage::Attachment.where(record_id: @graduation_album.id).where(blob_id: photo_path.path.to_i).first)
+          @mathed_face_images.push(ActiveStorage::Attachment.where(record_id: @graduation_album.id).where(blob_id: photo_path.path.to_i).first) if photo_path
         end
       end
     end

--- a/app/controllers/ranks_controller.rb
+++ b/app/controllers/ranks_controller.rb
@@ -8,6 +8,7 @@ class RanksController < ApplicationController
 
   def create
     @rank = current_user.ranks.build(params_rank)
+    @graduation_album = GraduationAlbum.find(params[:graduation_album_id])
     if @rank.save
       redirect_to graduation_album_rank_path(@rank.graduation_album, @rank), notice: 'ランキングを投稿しました'
     else

--- a/app/jobs/register_rekognition_job.rb
+++ b/app/jobs/register_rekognition_job.rb
@@ -22,6 +22,7 @@ class RegisterRekognitionJob < ApplicationJob
                                   }
                                 })
       next if resp.to_h[:face_records] == []
+
       image_detail = PhotoPath.new(graduation_album_id: image.record_id, path: image.blob_id.to_s,
                                    image_id: resp.to_h[:face_records][0][:face][:image_id], s3_file_name: image.key)
       image_detail.save!

--- a/app/jobs/register_rekognition_job.rb
+++ b/app/jobs/register_rekognition_job.rb
@@ -2,19 +2,14 @@ class RegisterRekognitionJob < ApplicationJob
   queue_as :default
 
   def perform(image_ids)
+    graduation_album_id = ActiveStorage::Attachment.find(image_ids.first).record_id
+    graduation_album = GraduationAlbum.find(graduation_album_id)
+    graduation_album.update_attribute(:analysis_status, 'doing')
     credentials = Aws::Credentials.new(
       ENV.fetch('AWS_ACCESS_KEY_ID', nil),
       ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
     )
     client = Aws::Rekognition::Client.new credentials: credentials
-    # unless PhotoCollection.find_by(name: 'graduation_album')
-    # client.create_collection({
-    #  collection_id: 'graduation_album'
-    #  })
-    # collection = PhotoCollection.new
-    # collection.name = 'graduation_album'
-    # collection.save
-    # end
     image_ids.each do |id|
       image = ActiveStorage::Attachment.find(id)
       resp = client.index_faces({
@@ -27,10 +22,10 @@ class RegisterRekognitionJob < ApplicationJob
                                   }
                                 })
       next if resp.to_h[:face_records] == []
-
       image_detail = PhotoPath.new(graduation_album_id: image.record_id, path: image.blob_id.to_s,
                                    image_id: resp.to_h[:face_records][0][:face][:image_id], s3_file_name: image.key)
       image_detail.save!
     end
+    graduation_album.update_attribute(:analysis_status, 'done')
   end
 end

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -4,11 +4,12 @@
 #
 # Table name: graduation_albums
 #
-#  id         :bigint           not null, primary key
-#  album_name :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id              :bigint           not null, primary key
+#  album_name      :string           not null
+#  analysis_status :integer          default(0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :bigint           not null
 #
 # Indexes
 #
@@ -31,6 +32,7 @@ class GraduationAlbum < ApplicationRecord
   has_many :photo_paths, dependent: :destroy
 
   validates :album_name, presence: true, length: { maximum: 255 }
+  enum analysis_status: { before: 0, doing: 1, done: 2 }
 
   FILE_NUMBER_LIMIT = 10
   validate :validate_number_of_files

--- a/app/views/menbers/show.html.erb
+++ b/app/views/menbers/show.html.erb
@@ -10,14 +10,22 @@
             <div class="text-blue-500 md:text-lg font-bold text-center">
               <%= @menber.name %>
             </div>
-            <div class='mx-auto'>
+          <% if @graduation_album.analysis_status == 'done'%>
+          <div class='flex justify-center'>
             <%= link_to graduation_album_menber_register_faces_path(@graduation_album, @menber), method: :post do %>
               <button class="bg-blue-500 hover:bg-blue-300 text-white rounded px-4 py-2">写真の取得</button>
             <% end %>
-            </div>
           </div>
-          <p class='pt-6 text-center text-blue-500'> アルバムに投稿された画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
-          <p class='pb-6 text-center text-blue-500'> プロフィール画像に顔が写っているかを確認してボタンをクリックしよう！</p>
+            <p class='pt-6 text-center text-blue-500'> アルバムに投稿された画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
+            <p class='pb-6 text-center text-blue-500'> プロフィール画像に顔が写っているかを確認してボタンをクリックしよう！</p>
+          <% elsif @graduation_album.analysis_status == 'doing' %>
+            <p class='pt-6 text-center text-blue-500'> アルバムに投稿された画像を分析中です</p>
+            <p class='pb-6 text-center text-blue-500'> 分析が終わるとアルバムに投稿された画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
+          <% else %>
+            <p class='pt-6 text-center text-blue-500'> アルバムに写真を投稿してみよう！</p>
+            <p class='pb-6 text-center text-blue-500'> 投稿するとアルバムの画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
+          <% end %>
+          </div>
       <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 md:gap-5 xl:gap-2">
         <% if @mathed_face_images && @mathed_face_images.count != 0 %>
           <% @mathed_face_images.each do |image| %>

--- a/db/migrate/20220808070712_add_analysis_status_to_graduation_albums.rb
+++ b/db/migrate/20220808070712_add_analysis_status_to_graduation_albums.rb
@@ -1,0 +1,5 @@
+class AddAnalysisStatusToGraduationAlbums < ActiveRecord::Migration[6.1]
+  def change
+    add_column :graduation_albums, :analysis_status, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_02_113151) do
+ActiveRecord::Schema.define(version: 2022_08_08_070712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,7 @@ ActiveRecord::Schema.define(version: 2022_08_02_113151) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "analysis_status", default: 0, null: false
     t.index ["user_id"], name: "index_graduation_albums_on_user_id"
   end
 

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -4,11 +4,12 @@
 #
 # Table name: graduation_albums
 #
-#  id         :bigint           not null, primary key
-#  album_name :string           not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  id              :bigint           not null, primary key
+#  album_name      :string           not null
+#  analysis_status :integer          default(0), not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  user_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/system/ranks_spec.rb
+++ b/spec/system/ranks_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe "Ranks", type: :system do
       end
     end
     describe 'ランキングの削除' do
-      fit 'ランキングの削除が成功する' do
+      it 'ランキングの削除が成功する' do
           rank
           visit graduation_album_rank_path(graduation_album, rank)
           page.accept_confirm do


### PR DESCRIPTION
## 関連するissue
close #159 

## 概要
以下を実行しました。

・アルバムに投稿された画像をactive jobで分析している途中にメンバーページから画像取得ボタンを押した場合に発生するエラーを解消。
・graduation_albumsテーブルにanalysis_statusカラムを追加してenumでbefore, doing, doneの３つの状態を区別するように変更。
・active jobで画像の分析が始まるとanalysis_statusをdoingに変更し、終了するとdoneに変更
・メンバーページに表示される内容をanalysis_statusの値によって切り替えるように変更

## 確認方法
画像を投稿している場合、画像を投稿したが分析が終わっていない場合、画像の分析が完了している場合のそれぞれでメンバー詳細ページに表示される内容が変更されることから確認できます。

## 懸念点
特になし。

## 参考記事
特になし。