### PR TITLE
Design: 画像のサイズを調節してPC閲覧時でも画像全体が閲覧できるよう変更#165

### DIFF
--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -34,13 +34,19 @@ class GraduationAlbum < ApplicationRecord
   validates :album_name, presence: true, length: { maximum: 255 }
   enum analysis_status: { before: 0, doing: 1, done: 2 }
 
-  FILE_NUMBER_LIMIT = 15
   validate :validate_number_of_files
+  validate :validate_number_of_album
 
   def validate_number_of_files
-    return if images.length <= FILE_NUMBER_LIMIT
+    return if images.length <= 15
 
-    errors.add(:images, "に添付できる画像は#{FILE_NUMBER_LIMIT}枚までです。")
+    errors.add(:images, "に添付できる画像は15枚までです。")
+  end
+
+  def validate_number_of_album
+    return if user.graduation_albums.length <= 2
+
+    errors.add(:id, "作成できるアルバムは2つまでです。")
   end
 
   def register_images

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -40,13 +40,13 @@ class GraduationAlbum < ApplicationRecord
   def validate_number_of_files
     return if images.length <= 15
 
-    errors.add(:images, "に添付できる画像は15枚までです。")
+    errors.add(:images, 'に添付できる画像は15枚までです。')
   end
 
   def validate_number_of_album
     return if user.graduation_albums.length <= 2
 
-    errors.add(:id, "作成できるアルバムは2つまでです。")
+    errors.add(:id, '作成できるアルバムは2つまでです。')
   end
 
   def register_images

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -8,8 +8,10 @@
         <div class="md:h-80 flex flex-col sm:flex-row bg-indigo-100 rounded-lg overflow-hidden">
           <!-- image - start -->
           <div class="w-full sm:w-1/2 lg:w-2/5 h-48 sm:h-auto order-first sm:order-none bg-indigo-100">
-            <%= link_to graduation_album_event_path(event.graduation_album, event) do %>
-              <%= image_tag event.event_photos.blobs.first, class:'object-contai', loading:"lazy"%>
+            <% if event.event_photos.blobs.first %>
+              <%= link_to graduation_album_event_path(event.graduation_album, event) do %>
+                <%= image_tag event.event_photos.blobs.first, class:'object-contai', loading:"lazy"%>
+              <% end %>
             <% end %>
           </div>
           <!-- image - end -->

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -9,14 +9,12 @@
           <!-- image - start -->
           <div class="w-full sm:w-1/2 lg:w-2/5 h-48 sm:h-auto order-first sm:order-none bg-indigo-100">
             <%= link_to graduation_album_event_path(event.graduation_album, event) do %>
-              <% event.event_photos.each do |photo| %>
-                <%= image_tag photo, class:'object-contai', loading:"lazy"%>
-              <% end %>
+              <%= image_tag event.event_photos.blobs.first, class:'object-contai', loading:"lazy"%>
             <% end %>
           </div>
           <!-- image - end -->
           <!-- content - start -->
-          <div class="w-full sm:w-1/2 lg:w-3/5 flex flex-col p-4 sm:p-8">
+          <div class="w-full sm:w-full flex flex-col p-4 sm:p-8">
             <h2 class="text-indigo-700 text-xl md:text-2xl lg:text-4xl font-bold mb-4"><%= link_to event.title, graduation_album_event_path(event.graduation_album, event)%></h2>
             <p class="max-w-md text-indigo-700 mb-8"><%= simple_format(event.description) %></p>
             <div class="mt-auto text-right">

--- a/app/views/ranks/_rank.html.erb
+++ b/app/views/ranks/_rank.html.erb
@@ -21,7 +21,8 @@
       </div>
       <% rank.rank_choices.order(answers_count: "DESC").with_attached_rank_choice_image.each_with_index do |choice, index| %>
         <% if choice.rank_choice_image.variant( rotate: 2 )  %>
-            <div class="group h-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative p-4">
+          <div class="flex justify-center">
+            <div class="group h-80 w-80 flex items-end bg-gray-100 rounded-lg overflow-hidden shadow-lg relative p-4">
             <% if index.even? %>
               <%= image_tag choice.rank_choice_image.variant( rotate: 2 ).processed, loading:"lazy", alt:"Photo by Fakurian Design", class:"w-full h-full object-cover object-center absolute inset-0 transition duration-200" %>
             <% else %>
@@ -29,6 +30,7 @@
             <% end %>
               <div class="bg-gradient-to-t from-gray-800 via-transparent to-transparent opacity-50 absolute inset-0 pointer-events-none"></div>
             </div>
+          </div>
         <% end %>
         <div class="grid grid-cols-12 flex items-center my-4">
           <div class="text-sm sm:text-2xl col-span-3 text-sm font-medium text-pink-600 dark:text-pink-500 text-center">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -44,3 +44,7 @@ ja:
           attributes:
             graduation_album_id:
               format: '%{message}'
+        graduation_album:
+          attributes:
+            id:
+              format: '%{message}'


### PR DESCRIPTION
## 関連するissue
close #165 
close #167 

## 概要
以下を実行しました。

・アルバム詳細画面でイベントのサムネイル写真の全体が表示されるようにデザインを変更
・アルバム詳細画面でランキングのサムネイル写真の全体が表示されるようにデザインを変更
・1人のユーザーが作成できるアルバム数を2つに制限

## 懸念点
特になし。

## 参考記事
特になし。