### PR TITLE
Design: 画像に枠組みを追加#169

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -79,65 +79,37 @@ input[type=file][data-direct-upload-url][disabled] {
 }
 
 .photo {
-
   border: 10px solid #999933;
-
   box-shadow: 0 0 1px #ccc, 1px 1px 2px rgba(50, 50, 50, 0.2);
-
   position: relative;
-
 }
 
 .photo::before {
-
   content: '';
-
   display: block;
-
   width: 0;
-
   height: 0;
-
   border-style: solid;
-
-  border-width: 80px 80px 0 0;
-
+  border-width: 40px 40px 0 0;
   border-color: #f9eccd transparent transparent transparent;
-
   box-shadow: -1px -1px 1px rgba(50, 50, 50, 0.1);
-
   position: absolute;
-
   left: -15px;
-
   top: -15px;
-
 }
 
 .photo::after {
-
   content: '';
-
   display: block;
-
   width: 0;
-
   height: 0;
-
   border-style: solid;
-
-  border-width: 0 0 80px 80px;
-
+  border-width: 0 0 40px 40px;
   border-color: transparent transparent #ccc transparent;
-
   box-shadow: 1px 1px 1px rgba(50, 50, 50, 0.1);
-
   position: absolute;
-
   right: -15px;
-
   bottom: -15px;
-
 }
 
 .boxmi14 {

--- a/app/views/menbers/show.html.erb
+++ b/app/views/menbers/show.html.erb
@@ -13,11 +13,9 @@
           <% if @graduation_album.analysis_status == 'done'%>
           <div class='flex justify-center'>
             <%= link_to graduation_album_menber_register_faces_path(@graduation_album, @menber), method: :post do %>
-              <button class="bg-blue-500 hover:bg-blue-300 text-white rounded px-4 py-2">写真の取得</button>
+              <button class="bg-blue-500 hover:bg-blue-300 text-white rounded px-4 py-2"><%=@menber.name%>さんの写真を取得</button>
             <% end %>
           </div>
-            <p class='pt-6 text-center text-blue-500'> アルバムに投稿された画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
-            <p class='pb-6 text-center text-blue-500'> プロフィール画像に顔が写っているかを確認してボタンをクリックしよう！</p>
           <% elsif @graduation_album.analysis_status == 'doing' %>
             <p class='pt-6 text-center text-blue-500'> アルバムに投稿された画像を分析中です</p>
             <p class='pb-6 text-center text-blue-500'> 分析が終わるとアルバムに投稿された画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
@@ -26,13 +24,15 @@
             <p class='pb-6 text-center text-blue-500'> 投稿するとアルバムの画像の中から<%=@menber.name%>さんが写っている写真をこのページに表示できます</p>
           <% end %>
           </div>
-      <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 md:gap-5 xl:gap-2">
-        <% if @mathed_face_images && @mathed_face_images.count != 0 %>
-          <% @mathed_face_images.each do |image| %>
-            <%= image_tag image , size: '240x240'%>
-          <% end %> 
-        <% end %>
-      </div>
+          <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 md:gap-5 xl:gap-2 pt-6">
+            <% if @mathed_face_images && @mathed_face_images.count != 0 %>
+              <% @mathed_face_images.each do |image| %>
+                <div class="photo transform -rotate-12">
+                  <%= image_tag image.variant(gravity: :center, resize:"640x640^", crop:"640x640+0+0").processed %>
+                </div>
+              <% end %> 
+            <% end %>
+          </div>
       <h2 class="text-red-400 text-2xl lg:text-3xl font-bold text-center pt-4 mb-4 md:mb-6 pt-10"><i class="fa-regular fa-comment"></i>メンバーからのメッセージ</h2>
     </div>
     <%= render 'message_for_each_menbers/message_for_each_menbers', { message_for_each_menbers: @message_for_each_menbers } %>


### PR DESCRIPTION
## 関連するissue
close #169 

## 概要
以下を実行しました。

・メンバー詳細ページに表示される同一人物の写真に枠組みを追加
・取得した画像を同じサイズにするためvariantを使用して画像をリサイズ

## 確認事項
特になし

## 確認方法
メンバー詳細ページに移動して画像を取得ボタンを押すと枠組みのある画像が表示されます。

## 懸念点
特になし。

## 参考記事
特になし。