### PR TITLE
Fix album grup bug#168

### DIFF
--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -42,8 +42,8 @@ class GraduationAlbumsController < ApplicationController
 
   def update
     set_search
+    @graduation_album.set_album_menbers(params[:graduation_album][:user_ids], current_user.id)
     if @graduation_album.update(graduation_album_params)
-      @graduation_album.users << current_user
       redirect_to graduation_album_path(@graduation_album), notice: '編集に成功しました'
     else
       flash.now['alert'] = '編集に失敗しました'

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -24,7 +24,7 @@ class GraduationAlbumsController < ApplicationController
 
   def create
     set_search
-    @graduation_album = current_user.graduation_albums.new(graduation_album_params)
+    @graduation_album = current_user.graduation_albums.build(graduation_album_params)
     @graduation_album.set_album_menbers(params[:graduation_album][:user_ids], current_user.id)
     if @graduation_album.save
       @graduation_album.register_images

--- a/app/controllers/graduation_albums_controller.rb
+++ b/app/controllers/graduation_albums_controller.rb
@@ -24,8 +24,8 @@ class GraduationAlbumsController < ApplicationController
 
   def create
     set_search
-    @graduation_album = current_user.graduation_albums.build(graduation_album_params)
-    @graduation_album.users << current_user
+    @graduation_album = current_user.graduation_albums.new(graduation_album_params)
+    @graduation_album.set_album_menbers(params[:graduation_album][:user_ids], current_user.id)
     if @graduation_album.save
       @graduation_album.register_images
       redirect_to graduation_album_path(@graduation_album), notice: '作成に成功しました'
@@ -65,7 +65,7 @@ class GraduationAlbumsController < ApplicationController
   private
 
   def graduation_album_params
-    params.require(:graduation_album).permit(:album_name, { user_ids: [] }, images: [])
+    params.require(:graduation_album).permit(:album_name, images: [])
   end
 
   def set_graduation_album

--- a/app/models/album_user.rb
+++ b/app/models/album_user.rb
@@ -21,4 +21,5 @@
 class AlbumUser < ApplicationRecord
   belongs_to :graduation_album
   belongs_to :user
+  validates :user_id, uniqueness: { scope: :graduation_album_id }
 end

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -57,6 +57,7 @@ class GraduationAlbum < ApplicationRecord
   end
 
   def set_album_menbers(menber_ids, current_user)
+    menber_ids ||= []
     (menber_ids << current_user).reject(&:blank?).map(&:to_i).each do |id|
       users << User.find(id)
     end

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -58,7 +58,7 @@ class GraduationAlbum < ApplicationRecord
 
   def set_album_menbers(menber_ids, current_user)
     (menber_ids << current_user).reject(&:blank?).map(&:to_i).each do |id|
-      self.users << User.find(id)
+      users << User.find(id)
     end
   end
 end

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -55,4 +55,10 @@ class GraduationAlbum < ApplicationRecord
     image_ids = images.map(&:id)
     RegisterRekognitionJob.perform_later(image_ids)
   end
+
+  def set_album_menbers(menber_ids, current_user)
+    (menber_ids << current_user).reject(&:blank?).map(&:to_i).each do |id|
+      self.users << User.find(id)
+    end
+  end
 end


### PR DESCRIPTION
## 概要
アルバムにユーザーを追加する際の手順を「graduation_albumのインスタンスから自動的に保存する」形から「受け取ったidを1つずつAlbumUserモデルに保存する形」に変更しました。
これによって、アルバム失敗時に以下のように「Usersは不正な値です」というメッセージが表示される不具合を解消しました。
[![Image from Gyazo](https://i.gyazo.com/06e5a41b59f9f47c8f1994b8dcdc09f7.png)](https://gyazo.com/06e5a41b59f9f47c8f1994b8dcdc09f7)

close #168

## 実行手順
1, graduation_album_paramsを変更する
graduation_albums_controller.rbのgraduation_album_paramsからuser_idsを削除します。
削除理由はparamsにuser_idsが含まれているとbuildした時点で自動的にAlbumUserのインスタンスも生成され、@graduation_album.save時に自動で保存され意図した挙動を行えないためです。
```ruby
def graduation_album_params
    params.require(:graduation_album).permit(:album_name, :title, { photos: [] })
end
```

2, graduation_album.rbにメソッドを定義する
menber_idsがnullの場合にエラーが発生しないようにnullガードを使用しています。
```ruby
def set_album_menbers(menber_ids, current_user)
  menber_ids ||= []
  (menber_ids << current_user).reject(&:blank?).map(&:to_i).each do |id|
  users << User.find(id)
end
```

3, create・updateアクションをメソッドを使用した形に変更する
```ruby
def create
  set_search
  @graduation_album = current_user.graduation_albums.build(graduation_album_params)
  @graduation_album.set_album_menbers(params[:graduation_album][:user_ids], current_user.id)
  if @graduation_album.save
    @graduation_album.register_images
    redirect_to graduation_album_path(@graduation_album), notice: '作成に成功しました'
  else
    flash.now['alert'] = '作成に失敗しました'
    render :new
  end
end
```

```ruby
def update
  set_search
  @graduation_album.set_album_menbers(params[:graduation_album][:user_ids], current_user.id)
  if @graduation_album.update(graduation_album_params)
    redirect_to graduation_album_path(@graduation_album), notice: '編集に成功しました'
  else
    flash.now['alert'] = '編集に失敗しました'
    render :edit
  end
end
```

## 確認方法
git clone後はrubyのバージョンを
```
% rbenv local 3.1.2
```
で設定してください。
 このブランチの内容をローカルにfetchして動作確認する場合は
```
git fetch origin pull/2/head:Fix_album_grup_bug#168
```
を実行してください。
1. `bundle install`を実行します。
2. `rails db:create`を実行します。
3. `rails s`を実行し、サーバーが立ち上がることを確認してください。
4. アルバム作成画面に移動してアルバム名を空白にしたまま作成ボタンを押して下さい。
以下のように「Usersの値は不正です」というメッセージが表示されなくなったことが確認できます。
[![Image from Gyazo](https://i.gyazo.com/2f32275e69b3d49ec9db048a2dc2afc4.png)](https://gyazo.com/2f32275e69b3d49ec9db048a2dc2afc4)
