### PR TITLE
Add validation #173

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,8 +28,8 @@ class Event < ApplicationRecord
   has_many :event_comments, dependent: :destroy
 
   validates :title, :description, :event_date, presence: true
-  validates :title, length: { maximum: 255 }
-  validates :description, length: { maximum: 65_535 }
+  validates :title, length: { maximum: 30 }
+  validates :description, length: { maximum: 200 }
   FILE_NUMBER_LIMIT = 10
   validate :validate_number_of_files
 

--- a/app/models/graduation_album.rb
+++ b/app/models/graduation_album.rb
@@ -31,7 +31,7 @@ class GraduationAlbum < ApplicationRecord
   has_many :suprise_messages, dependent: :destroy
   has_many :photo_paths, dependent: :destroy
 
-  validates :album_name, presence: true, length: { maximum: 255 }
+  validates :album_name, presence: true, length: { maximum: 30 }
   enum analysis_status: { before: 0, doing: 1, done: 2 }
 
   validate :validate_number_of_files

--- a/app/models/message_for_each_menber.rb
+++ b/app/models/message_for_each_menber.rb
@@ -26,6 +26,6 @@ class MessageForEachMenber < ApplicationRecord
   belongs_to :user
   belongs_to :graduation_album
 
-  validates :body, presence: true, length: { maximum: 65_535 }
+  validates :body, presence: true, length: { maximum: 200 }
   validates_uniqueness_of :graduation_album_id,  message: 'メッセージは1人1つまでです', scope: :user_id
 end

--- a/app/models/message_for_everyone.rb
+++ b/app/models/message_for_everyone.rb
@@ -25,6 +25,6 @@ class MessageForEveryone < ApplicationRecord
   belongs_to :user
   belongs_to :graduation_album
 
-  validates :body, presence: true, length: { maximum: 65_535 }
+  validates :body, presence: true, length: { maximum: 200 }
   validates_uniqueness_of :graduation_album_id,  message: 'メッセージは1人1つまでです', scope: :user_id
 end

--- a/app/models/rank.rb
+++ b/app/models/rank.rb
@@ -27,6 +27,6 @@ class Rank < ApplicationRecord
   has_many :answers, dependent: :destroy
 
   validates :rank_title, :rank_description, presence: true
-  validates :rank_title, length: { maximum: 255 }
-  validates :rank_description, length: { maximum: 65_535 }
+  validates :rank_title, length: { maximum: 40 }
+  validates :rank_description, length: { maximum: 250 }
 end

--- a/app/models/rank.rb
+++ b/app/models/rank.rb
@@ -27,6 +27,6 @@ class Rank < ApplicationRecord
   has_many :answers, dependent: :destroy
 
   validates :rank_title, :rank_description, presence: true
-  validates :rank_title, length: { maximum: 40 }
-  validates :rank_description, length: { maximum: 250 }
+  validates :rank_title, length: { maximum: 20 }
+  validates :rank_description, length: { maximum: 200 }
 end

--- a/app/models/rank_choice.rb
+++ b/app/models/rank_choice.rb
@@ -22,5 +22,5 @@ class RankChoice < ApplicationRecord
   belongs_to :rank
   has_many :answers, dependent: :destroy
 
-  validates :content, presence: true, length: { maximum: 255 }
+  validates :content, presence: true, length: { maximum: 30 }
 end

--- a/app/models/rank_choice.rb
+++ b/app/models/rank_choice.rb
@@ -22,5 +22,5 @@ class RankChoice < ApplicationRecord
   belongs_to :rank
   has_many :answers, dependent: :destroy
 
-  validates :content, presence: true, length: { maximum: 30 }
+  validates :content, presence: true, length: { maximum: 20 }
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -25,4 +25,5 @@ class Relationship < ApplicationRecord
 
   validates :user_id, presence: true
   validates :follow_id, presence: true
+  validates :user_id, uniqueness: { scope: :follow_id }
 end

--- a/app/models/suprise_message.rb
+++ b/app/models/suprise_message.rb
@@ -28,6 +28,6 @@ class SupriseMessage < ApplicationRecord
 
   enum state: { publish_wait: 0, published: 1 }
   validates :suprise_title, :suprise_message, :suprise_time, presence: true
-  validates :suprise_title, length: { maximum: 30 }
+  validates :suprise_title, length: { maximum: 20 }
   validates :suprise_message, length: { maximum: 500 }
 end

--- a/app/models/suprise_message.rb
+++ b/app/models/suprise_message.rb
@@ -28,6 +28,6 @@ class SupriseMessage < ApplicationRecord
 
   enum state: { publish_wait: 0, published: 1 }
   validates :suprise_title, :suprise_message, :suprise_time, presence: true
-  validates :suprise_title, length: { maximum: 255 }
-  validates :suprise_message, length: { maximum: 65_535 }
+  validates :suprise_title, length: { maximum: 30 }
+  validates :suprise_message, length: { maximum: 500 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User < ApplicationRecord
 
   validates :email, uniqueness: true
   validates :email, presence: true
-  validates :name, presence: true, length: { maximum: 255 }
+  validates :name, presence: true, length: { maximum: 20 }
 
   def own?(object)
     id == object.user_id

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -43,28 +43,28 @@ RSpec.describe Event, type: :model do
       expect(event_without_description.errors[:description]).to eq ['を入力してください']
     end
 
-    it '詳細が65535文字の場合有効であること' do
-      event_with_65535_character_description = build(:event, description: 'a' * 65_535)
-      expect(event_with_65535_character_description).to be_valid
-      expect(event_with_65535_character_description.errors).to be_empty
+    it '詳細が200文字の場合有効であること' do
+      event_with_200_character_description = build(:event, description: 'a' * 200)
+      expect(event_with_200_character_description).to be_valid
+      expect(event_with_200_character_description.errors).to be_empty
     end
 
-    it '詳細が65536文字の場合不正であること' do
-      event_with_256_character_description = build(:event, description: 'a' * 65_536)
-      expect(event_with_256_character_description).to be_invalid
-      expect(event_with_256_character_description.errors[:description]).to eq ['は65535文字以内で入力してください']
+    it '詳細が201文字の場合不正であること' do
+      event_with_201_character_description = build(:event, description: 'a' * 201)
+      expect(event_with_201_character_description).to be_invalid
+      expect(event_with_201_character_description.errors[:description]).to eq ['は200文字以内で入力してください']
     end
 
-    it 'タイトルが255文字の場合有効であること' do
-      event_with_65535_character_title = build(:event, title: 'a' * 255)
-      expect(event_with_65535_character_title).to be_valid
-      expect(event_with_65535_character_title.errors).to be_empty
+    it 'タイトルが30文字の場合有効であること' do
+      event_with_30_character_title = build(:event, title: 'a' * 30)
+      expect(event_with_30_character_title).to be_valid
+      expect(event_with_30_character_title.errors).to be_empty
     end
 
-    it 'タイトルが256文字の場合不正であること' do
-      event_with_256_character_title = build(:event, title: 'a' * 256)
-      expect(event_with_256_character_title).to be_invalid
-      expect(event_with_256_character_title.errors[:title]).to eq ['は255文字以内で入力してください']
+    it 'タイトルが31文字の場合不正であること' do
+      event_with_31_character_title = build(:event, title: 'a' * 31)
+      expect(event_with_31_character_title).to be_invalid
+      expect(event_with_31_character_title.errors[:title]).to eq ['は30文字以内で入力してください']
     end
   end
 end

--- a/spec/models/graduation_album_spec.rb
+++ b/spec/models/graduation_album_spec.rb
@@ -35,16 +35,16 @@ RSpec.describe GraduationAlbum, type: :model do
       expect(graduation_album_without_album_name.errors[:album_name]).to eq ['を入力してください']
     end
 
-    it 'アルバム名が255文字の場合有効であること' do
-      graduation_album_with_255_character_album_name = build(:graduation_album, album_name: 'a' * 255)
-      expect(graduation_album_with_255_character_album_name).to be_valid
-      expect(graduation_album_with_255_character_album_name.errors).to be_empty
+    it 'アルバム名が30文字の場合有効であること' do
+      graduation_album_with_30_character_album_name = build(:graduation_album, album_name: 'a' * 30)
+      expect(graduation_album_with_30_character_album_name).to be_valid
+      expect(graduation_album_with_30_character_album_name.errors).to be_empty
     end
 
-    it 'アルバム名が256文字の場合不正であること' do
-      graduation_album_with_256_character_album_name = build(:graduation_album, album_name: 'a' * 256)
-      expect(graduation_album_with_256_character_album_name).to be_invalid
-      expect(graduation_album_with_256_character_album_name.errors[:album_name]).to eq ['は255文字以内で入力してください']
+    it 'アルバム名が31文字の場合不正であること' do
+      graduation_album_with_31_character_album_name = build(:graduation_album, album_name: 'a' * 31)
+      expect(graduation_album_with_31_character_album_name).to be_invalid
+      expect(graduation_album_with_31_character_album_name.errors[:album_name]).to eq ['は30文字以内で入力してください']
     end
   end
 end

--- a/spec/models/message_for_each_menber_spec.rb
+++ b/spec/models/message_for_each_menber_spec.rb
@@ -26,7 +26,7 @@ require 'rails_helper'
 
 RSpec.describe MessageForEachMenber, type: :model do
   describe 'バリデーション' do
-    it 'メッセージが存在し、65535字以内の場合有効であること' do
+    it 'メッセージが存在する場合有効であること' do
       message_for_each_menber = build(:message_for_each_menber)
       expect(message_for_each_menber).to be_valid
       expect(message_for_each_menber.errors).to be_empty
@@ -36,15 +36,15 @@ RSpec.describe MessageForEachMenber, type: :model do
       expect(message_for_each_menber_without_body).to be_invalid
       expect(message_for_each_menber_without_body.errors[:body]).to eq ['を入力してください']
     end
-    it 'タイトルが255文字の場合有効であること' do
-      message_for_each_menber_with_65535_character_body = build(:message_for_each_menber, body: 'a' * 65_535)
-      expect(message_for_each_menber_with_65535_character_body).to be_valid
-      expect(message_for_each_menber_with_65535_character_body.errors).to be_empty
+    it 'タイトルが200文字の場合有効であること' do
+      message_for_each_menber_with_200_character_body = build(:message_for_each_menber, body: 'a' * 200)
+      expect(message_for_each_menber_with_200_character_body).to be_valid
+      expect(message_for_each_menber_with_200_character_body.errors).to be_empty
     end
-    it 'タイトルが256文字の場合不正であること' do
-      message_for_each_menber_with_256_character_body = build(:message_for_each_menber, body: 'a' * 65_536)
-      expect(message_for_each_menber_with_256_character_body).to be_invalid
-      expect(message_for_each_menber_with_256_character_body.errors[:body]).to eq ['は65535文字以内で入力してください']
+    it 'タイトルが201文字の場合不正であること' do
+      message_for_each_menber_with_201_character_body = build(:message_for_each_menber, body: 'a' * 201)
+      expect(message_for_each_menber_with_201_character_body).to be_invalid
+      expect(message_for_each_menber_with_201_character_body.errors[:body]).to eq ['は200文字以内で入力してください']
     end
   end
 end

--- a/spec/models/message_for_everyone_spec.rb
+++ b/spec/models/message_for_everyone_spec.rb
@@ -37,16 +37,16 @@ RSpec.describe MessageForEveryone, type: :model do
       expect(message_for_everyone_without_body.errors[:body]).to eq ['を入力してください']
     end
 
-    it 'タイトルが255文字の場合有効であること' do
-      message_for_everyone_with_65535_character_body = build(:message_for_everyone, body: 'a' * 65_535)
-      expect(message_for_everyone_with_65535_character_body).to be_valid
-      expect(message_for_everyone_with_65535_character_body.errors).to be_empty
+    it 'タイトルが200文字の場合有効であること' do
+      message_for_everyone_with_200_character_body = build(:message_for_everyone, body: 'a' * 200)
+      expect(message_for_everyone_with_200_character_body).to be_valid
+      expect(message_for_everyone_with_200_character_body.errors).to be_empty
     end
 
-    it 'タイトルが256文字の場合不正であること' do
-      message_for_everyone_with_256_character_body = build(:message_for_everyone, body: 'a' * 65_536)
-      expect(message_for_everyone_with_256_character_body).to be_invalid
-      expect(message_for_everyone_with_256_character_body.errors[:body]).to eq ['は65535文字以内で入力してください']
+    it 'タイトルが201文字の場合不正であること' do
+      message_for_everyone_with_201_character_body = build(:message_for_everyone, body: 'a' * 201)
+      expect(message_for_everyone_with_201_character_body).to be_invalid
+      expect(message_for_everyone_with_201_character_body.errors[:body]).to eq ['は200文字以内で入力してください']
     end
   end
 end

--- a/spec/models/rank_choice_spec.rb
+++ b/spec/models/rank_choice_spec.rb
@@ -33,16 +33,16 @@ RSpec.describe RankChoice, type: :model do
       expect(rank_choice_without_content.errors[:content]).to eq ['を入力してください']
     end
 
-    it 'contentが255文字の場合有効であること' do
-      rank_choice_with_255_character_content = build(:rank_choice, content: 'a' * 255)
-      expect(rank_choice_with_255_character_content).to be_valid
-      expect(rank_choice_with_255_character_content.errors).to be_empty
+    it 'contentが20文字の場合有効であること' do
+      rank_choice_with_20_character_content = build(:rank_choice, content: 'a' * 20)
+      expect(rank_choice_with_20_character_content).to be_valid
+      expect(rank_choice_with_20_character_content.errors).to be_empty
     end
 
-    it 'contentが256文字の場合不正であること' do
-      rank_choice_with_256_character_content = build(:rank_choice, content: 'a' * 256)
-      expect(rank_choice_with_256_character_content).to be_invalid
-      expect(rank_choice_with_256_character_content.errors[:content]).to eq ['は255文字以内で入力してください']
+    it 'contentが21文字の場合不正であること' do
+      rank_choice_with_21_character_content = build(:rank_choice, content: 'a' * 21)
+      expect(rank_choice_with_21_character_content).to be_invalid
+      expect(rank_choice_with_21_character_content.errors[:content]).to eq ['は20文字以内で入力してください']
     end
   end
 end

--- a/spec/models/rank_spec.rb
+++ b/spec/models/rank_spec.rb
@@ -42,28 +42,28 @@ RSpec.describe Rank, type: :model do
       expect(rank_without_rank_description.errors[:rank_description]).to eq ['を入力してください']
     end
 
-    it '詳細が65535文字の場合有効であること' do
-      rank_with_65535_character_rank_description = build(:rank, rank_description: 'a' * 65_535)
-      expect(rank_with_65535_character_rank_description).to be_valid
-      expect(rank_with_65535_character_rank_description.errors).to be_empty
+    it '詳細が200文字の場合有効であること' do
+      rank_with_200_character_rank_description = build(:rank, rank_description: 'a' * 200)
+      expect(rank_with_200_character_rank_description).to be_valid
+      expect(rank_with_200_character_rank_description.errors).to be_empty
     end
 
-    it '詳細が65536文字の場合不正であること' do
-      rank_with_256_character_rank_description = build(:rank, rank_description: 'a' * 65_536)
-      expect(rank_with_256_character_rank_description).to be_invalid
-      expect(rank_with_256_character_rank_description.errors[:rank_description]).to eq ['は65535文字以内で入力してください']
+    it '詳細が200文字の場合不正であること' do
+      rank_with_200_character_rank_description = build(:rank, rank_description: 'a' * 201)
+      expect(rank_with_200_character_rank_description).to be_invalid
+      expect(rank_with_200_character_rank_description.errors[:rank_description]).to eq ['は200文字以内で入力してください']
     end
 
-    it 'タイトルが255文字の場合有効であること' do
-      rank_with_65535_character_rank_title = build(:rank, rank_title: 'a' * 255)
-      expect(rank_with_65535_character_rank_title).to be_valid
-      expect(rank_with_65535_character_rank_title.errors).to be_empty
+    it 'タイトルが20文字の場合有効であること' do
+      rank_with_20_character_rank_title = build(:rank, rank_title: 'a' * 20)
+      expect(rank_with_20_character_rank_title).to be_valid
+      expect(rank_with_20_character_rank_title.errors).to be_empty
     end
 
-    it 'タイトルが256文字の場合不正であること' do
-      rank_with_256_character_rank_title = build(:rank, rank_title: 'a' * 256)
-      expect(rank_with_256_character_rank_title).to be_invalid
-      expect(rank_with_256_character_rank_title.errors[:rank_title]).to eq ['は255文字以内で入力してください']
+    it 'タイトルが21文字の場合不正であること' do
+      rank_with_21_character_rank_title = build(:rank, rank_title: 'a' * 21)
+      expect(rank_with_21_character_rank_title).to be_invalid
+      expect(rank_with_21_character_rank_title.errors[:rank_title]).to eq ['は20文字以内で入力してください']
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,16 +64,16 @@ RSpec.describe User, type: :model do
       expect(user_without_name.errors[:name]).to eq ['を入力してください']
     end
 
-    it '名前が255文字の場合有効であること' do
-      user_with_255_character_name = build(:user, name: 'a' * 255)
+    it '名前が20文字の場合有効であること' do
+      user_with_255_character_name = build(:user, name: 'a' * 20)
       expect(user_with_255_character_name).to be_valid
       expect(user_with_255_character_name.errors).to be_empty
     end
 
-    it '名前が256文字の場合不正であること' do
-      user_without_name = build(:user, name: 'a' * 256)
+    it '名前が21文字の場合不正であること' do
+      user_without_name = build(:user, name: 'a' * 21)
       expect(user_without_name).to be_invalid
-      expect(user_without_name.errors[:name]).to eq ['は255文字以内で入力してください']
+      expect(user_without_name.errors[:name]).to eq ['は20文字以内で入力してください']
     end
   end
 end


### PR DESCRIPTION
## 関連するissue
close #173

## 概要

・文字数に関わるモデルのバリデーションの文字数をデザインが崩れないように減らしました。
・Relationshipモデルにuser_idとfollow_idは1つまでにするバリデーションを追加しました。
・変更した部分model specを変更

## 実装手順

1, titleやnameなどの短い文字列の文字数を削減しました。
255文字までだったものは30文字までに変更しました。
```
validates :album_name, presence: true, length: { maximum: 30 }
```

2, text型の長い文字列は200文字までに変更しました。
```
validates :body, presence: true, length: { maximum: 200 }
```

3, model specも変更に伴い修正する
```
it 'タイトルが21文字の場合不正であること' do
  rank_with_21_character_rank_title = build(:rank, rank_title: 'a' * 21)
  expect(rank_with_21_character_rank_title).to be_invalid
  expect(rank_with_21_character_rank_title.errors[:rank_title]).to eq ['は20文字以内で入力してください']
end
```

```
it '詳細が200文字の場合不正であること' do
  rank_with_200_character_rank_description = build(:rank, rank_description: 'a' * 201)
  expect(rank_with_200_character_rank_description).to be_invalid
  expect(rank_with_200_character_rank_description.errors[:rank_description]).to eq ['は200文字以内で入力してください']
end
```

## 確認方法

1. ローカルにコピーします。``git fetch origin pull/173/head:Add_validation_173``
2. 文字数制限を超えた文字を入れて作成しようとすると以下のように文字数制限が表示されることから確認できます。
[![Image from Gyazo](https://i.gyazo.com/fa57dc8f4e26c93b8f63bad94aeac6fd.png)](https://gyazo.com/fa57dc8f4e26c93b8f63bad94aeac6fd)

## 影響範囲

既存のバリデーションを変更したのが多かったので他の作業への影響は大きくありません。

## コメント

特になしです。